### PR TITLE
Update AccessType, Add DB Table

### DIFF
--- a/backend/webapi.tests/Features/Parties/ProfileStatus.cs
+++ b/backend/webapi.tests/Features/Parties/ProfileStatus.cs
@@ -242,7 +242,7 @@ public class ProfileStatusTests : InMemoryDbTest
             {
                 new AccessRequest
                 {
-                    AccessType = AccessType.SAEforms
+                    AccessTypeCode = AccessTypeCode.SAEforms
                 }
             }
         });

--- a/backend/webapi/Data/Configuration/AccessTypeConfiguration.cs
+++ b/backend/webapi/Data/Configuration/AccessTypeConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Pidp.Data.Configuration;
+
+using Pidp.Models.Lookups;
+
+public class AccessTypeConfiguration : LookupTableConfiguration<AccessType, AccessTypeDataGenerator>
+{
+}

--- a/backend/webapi/Data/Migrations/20220602043551_AccessTypeTable.Designer.cs
+++ b/backend/webapi/Data/Migrations/20220602043551_AccessTypeTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Pidp.Data;
 namespace Pidp.Data.Migrations
 {
     [DbContext(typeof(PidpDbContext))]
-    partial class PidpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220602043551_AccessTypeTable")]
+    partial class AccessTypeTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/webapi/Data/Migrations/20220602043551_AccessTypeTable.cs
+++ b/backend/webapi/Data/Migrations/20220602043551_AccessTypeTable.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pidp.Data.Migrations
+{
+    public partial class AccessTypeTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "AccessType",
+                table: "AccessRequest",
+                newName: "AccessTypeCode");
+
+            migrationBuilder.CreateTable(
+                name: "AccessTypeLookup",
+                columns: table => new
+                {
+                    Code = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AccessTypeLookup", x => x.Code);
+                });
+
+            migrationBuilder.InsertData(
+                table: "AccessTypeLookup",
+                columns: new[] { "Code", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Special Authority eForms" },
+                    { 2, "HCIMWeb Account Transfer" },
+                    { 3, "HCIMWeb Enrolment" },
+                    { 4, "Driver Medical Fitness" }
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AccessTypeLookup");
+
+            migrationBuilder.RenameColumn(
+                name: "AccessTypeCode",
+                table: "AccessRequest",
+                newName: "AccessType");
+        }
+    }
+}

--- a/backend/webapi/Features/AccessRequests/DriverFitness.cs
+++ b/backend/webapi/Features/AccessRequests/DriverFitness.cs
@@ -12,6 +12,7 @@ using Pidp.Infrastructure.HttpClients.Mail;
 using Pidp.Infrastructure.HttpClients.Plr;
 using Pidp.Infrastructure.Services;
 using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class DriverFitness
 {
@@ -56,7 +57,7 @@ public class DriverFitness
                 .Where(party => party.Id == command.PartyId)
                 .Select(party => new
                 {
-                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessType == AccessType.DriverFitness),
+                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.DriverFitness),
                     party.PartyCertification!.Ipc,
                     party.Email
                 })
@@ -80,7 +81,7 @@ public class DriverFitness
             this.context.AccessRequests.Add(new AccessRequest
             {
                 PartyId = command.PartyId,
-                AccessType = AccessType.DriverFitness,
+                AccessTypeCode = AccessTypeCode.DriverFitness,
                 RequestedOn = this.clock.GetCurrentInstant()
             });
 

--- a/backend/webapi/Features/AccessRequests/HcimAccountTransfer.cs
+++ b/backend/webapi/Features/AccessRequests/HcimAccountTransfer.cs
@@ -10,7 +10,7 @@ using Pidp.Infrastructure.HttpClients.Keycloak;
 using Pidp.Infrastructure.HttpClients.Ldap;
 using Pidp.Infrastructure.HttpClients.Mail;
 using Pidp.Infrastructure.Services;
-using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class HcimAccountTransfer
 {
@@ -79,8 +79,8 @@ public class HcimAccountTransfer
                 .Where(party => party.Id == command.PartyId)
                 .Select(party => new
                 {
-                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessType == AccessType.HcimAccountTransfer
-                        || request.AccessType == AccessType.HcimEnrolment),
+                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.HcimAccountTransfer
+                        || request.AccessTypeCode == AccessTypeCode.HcimEnrolment),
                     DemographicsComplete = party.Email != null && party.Phone != null,
                     party.UserId,
                     party.Email
@@ -116,7 +116,7 @@ public class HcimAccountTransfer
             this.context.HcimAccountTransfers.Add(new Models.HcimAccountTransfer
             {
                 PartyId = command.PartyId,
-                AccessType = AccessType.HcimAccountTransfer,
+                AccessTypeCode = AccessTypeCode.HcimAccountTransfer,
                 RequestedOn = this.clock.GetCurrentInstant(),
                 LdapUsername = command.LdapUsername
             });

--- a/backend/webapi/Features/AccessRequests/HcimEnrolment.cs
+++ b/backend/webapi/Features/AccessRequests/HcimEnrolment.cs
@@ -11,6 +11,7 @@ using Pidp.Infrastructure.HttpClients.Keycloak;
 using Pidp.Infrastructure.HttpClients.Mail;
 using Pidp.Infrastructure.Services;
 using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class HcimEnrolment
 {
@@ -56,8 +57,8 @@ public class HcimEnrolment
                 .Where(party => party.Id == command.PartyId)
                 .Select(party => new
                 {
-                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessType == AccessType.HcimAccountTransfer
-                        || request.AccessType == AccessType.HcimEnrolment),
+                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.HcimAccountTransfer
+                        || request.AccessTypeCode == AccessTypeCode.HcimEnrolment),
                     DemographicsComplete = party.Email != null && party.Phone != null,
                     AdminEmail = party.AccessAdministrator!.Email,
                 })
@@ -76,7 +77,7 @@ public class HcimEnrolment
             this.context.HcimEnrolments.Add(new Models.HcimEnrolment
             {
                 PartyId = command.PartyId,
-                AccessType = AccessType.HcimEnrolment,
+                AccessTypeCode = AccessTypeCode.HcimEnrolment,
                 RequestedOn = this.clock.GetCurrentInstant(),
                 ManagesTasks = command.ManagesTasks,
                 ModifiesPhns = command.ModifiesPhns,

--- a/backend/webapi/Features/AccessRequests/Index.cs
+++ b/backend/webapi/Features/AccessRequests/Index.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 
 using Pidp.Data;
-using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class Index
 {
@@ -17,7 +17,7 @@ public class Index
     public class Model
     {
         public int PartyId { get; set; }
-        public AccessType AccessType { get; set; }
+        public AccessTypeCode AccessTypeCode { get; set; }
         public Instant RequestedOn { get; set; }
     }
 
@@ -40,7 +40,7 @@ public class Index
                 .Select(access => new Model
                 {
                     PartyId = access.PartyId,
-                    AccessType = access.AccessType,
+                    AccessTypeCode = access.AccessTypeCode,
                     RequestedOn = access.RequestedOn,
                 })
                 .ToListAsync();

--- a/backend/webapi/Features/AccessRequests/SAEforms.cs
+++ b/backend/webapi/Features/AccessRequests/SAEforms.cs
@@ -12,6 +12,7 @@ using Pidp.Infrastructure.HttpClients.Mail;
 using Pidp.Infrastructure.HttpClients.Plr;
 using Pidp.Infrastructure.Services;
 using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class SAEforms
 {
@@ -56,7 +57,7 @@ public class SAEforms
                 .Where(party => party.Id == command.PartyId)
                 .Select(party => new
                 {
-                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessType == AccessType.SAEforms),
+                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.SAEforms),
                     party.UserId,
                     party.Email,
                     party.FirstName,
@@ -81,7 +82,7 @@ public class SAEforms
             this.context.AccessRequests.Add(new AccessRequest
             {
                 PartyId = command.PartyId,
-                AccessType = AccessType.SAEforms,
+                AccessTypeCode = AccessTypeCode.SAEforms,
                 RequestedOn = this.clock.GetCurrentInstant()
             });
 

--- a/backend/webapi/Features/Admin/MappingProfile.cs
+++ b/backend/webapi/Features/Admin/MappingProfile.cs
@@ -3,6 +3,7 @@ namespace Pidp.Features.Admin;
 using AutoMapper;
 
 using Pidp.Models;
+using Pidp.Models.Lookups;
 
 public class MappingProfile : Profile
 {
@@ -11,6 +12,6 @@ public class MappingProfile : Profile
         this.CreateProjection<Party, Index.Model>()
             .ForMember(dest => dest.ProviderName, opt => opt.MapFrom(src => $"{src.FirstName} {src.LastName}"))
             .ForMember(dest => dest.ProviderCollegeCode, opt => opt.MapFrom(src => src.PartyCertification!.CollegeCode))
-            .ForMember(dest => dest.SAEformsAccessRequest, opt => opt.MapFrom(src => src.AccessRequests.Any(accessRequest => accessRequest.AccessType == AccessType.SAEforms)));
+            .ForMember(dest => dest.SAEformsAccessRequest, opt => opt.MapFrom(src => src.AccessRequests.Any(accessRequest => accessRequest.AccessTypeCode == AccessTypeCode.SAEforms)));
     }
 }

--- a/backend/webapi/Features/Parties/MappingProfile.cs
+++ b/backend/webapi/Features/Parties/MappingProfile.cs
@@ -11,7 +11,7 @@ public class MappingProfile : Profile
         this.CreateProjection<Party, Demographics.Command>();
         this.CreateProjection<Party, ProfileStatus.ProfileStatusDto>()
             .IncludeMembers(party => party.PartyCertification)
-            .ForMember(dest => dest.CompletedEnrolments, opt => opt.MapFrom(src => src.AccessRequests.Select(x => x.AccessType)))
+            .ForMember(dest => dest.CompletedEnrolments, opt => opt.MapFrom(src => src.AccessRequests.Select(x => x.AccessTypeCode)))
             .ForMember(dest => dest.OrganizationDetailEntered, opt => opt.MapFrom(src => src.OrgainizationDetail != null))
             .ForMember(dest => dest.PlrRecordStatus, opt => opt.Ignore());
         this.CreateProjection<Party, WorkSetting.Command>()

--- a/backend/webapi/Features/Parties/ProfileStatus.Model.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.Model.cs
@@ -142,7 +142,7 @@ public partial class ProfileStatus
                     return;
                 }
 
-                if (profile.CompletedEnrolments.Contains(AccessType.DriverFitness))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.DriverFitness))
                 {
                     this.StatusCode = StatusCode.Complete;
                     return;
@@ -170,19 +170,19 @@ public partial class ProfileStatus
             protected override void SetAlertsAndStatus(ProfileStatusDto profile)
             {
                 // TODO revert [
-                // if (profile.CompletedEnrolments.Contains(AccessType.HcimAccountTransfer)
-                //    || profile.CompletedEnrolments.Contains(AccessType.HcimEnrolment))
+                // if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimAccountTransfer)
+                //    || profile.CompletedEnrolments.Contains(AccessTypeCode.HcimEnrolment))
                 // {
                 //     this.StatusCode = StatusCode.Hidden;
                 //     return;
                 // }
-                if (profile.CompletedEnrolments.Contains(AccessType.HcimAccountTransfer))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimAccountTransfer))
                 {
                     this.StatusCode = StatusCode.Complete;
                     return;
                 }
 
-                if (profile.CompletedEnrolments.Contains(AccessType.HcimEnrolment))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimEnrolment))
                 {
                     this.StatusCode = StatusCode.Hidden;
                     return;
@@ -204,20 +204,20 @@ public partial class ProfileStatus
             protected override void SetAlertsAndStatus(ProfileStatusDto profile)
             {
                 // TODO revert [
-                // if (profile.CompletedEnrolments.Contains(AccessType.HcimAccountTransfer)
-                //     || profile.CompletedEnrolments.Contains(AccessType.HcimEnrolment))
+                // if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimAccountTransfer)
+                //     || profile.CompletedEnrolments.Contains(AccessTypeCode.HcimEnrolment))
                 // {
                 //     this.StatusCode = StatusCode.Complete;
                 //     return;
                 // }
 
-                if (profile.CompletedEnrolments.Contains(AccessType.HcimAccountTransfer))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimAccountTransfer))
                 {
                     this.StatusCode = StatusCode.Hidden;
                     return;
                 }
 
-                if (profile.CompletedEnrolments.Contains(AccessType.HcimEnrolment))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.HcimEnrolment))
                 {
                     this.StatusCode = StatusCode.Complete;
                     return;
@@ -244,7 +244,7 @@ public partial class ProfileStatus
                     return;
                 }
 
-                if (profile.CompletedEnrolments.Contains(AccessType.SAEforms))
+                if (profile.CompletedEnrolments.Contains(AccessTypeCode.SAEforms))
                 {
                     this.StatusCode = StatusCode.Complete;
                     return;

--- a/backend/webapi/Features/Parties/ProfileStatus.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.cs
@@ -150,7 +150,7 @@ public partial class ProfileStatus
         public string? LicenceNumber { get; set; }
         public string? Ipc { get; set; }
         public bool OrganizationDetailEntered { get; set; }
-        public IEnumerable<AccessType> CompletedEnrolments { get; set; } = Enumerable.Empty<AccessType>();
+        public IEnumerable<AccessTypeCode> CompletedEnrolments { get; set; } = Enumerable.Empty<AccessTypeCode>();
 
         // Resolved after projection
         public PlrRecordStatus? PlrRecordStatus { get; set; }

--- a/backend/webapi/Models/AccessRequest.cs
+++ b/backend/webapi/Models/AccessRequest.cs
@@ -4,13 +4,7 @@ using NodaTime;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-public enum AccessType
-{
-    SAEforms = 1,
-    HcimAccountTransfer,
-    HcimEnrolment,
-    DriverFitness
-}
+using Pidp.Models.Lookups;
 
 [Table(nameof(AccessRequest))]
 public class AccessRequest : BaseAuditable
@@ -24,7 +18,7 @@ public class AccessRequest : BaseAuditable
 
     public Instant RequestedOn { get; set; }
 
-    public AccessType AccessType { get; set; }
+    public AccessTypeCode AccessTypeCode { get; set; }
 }
 
 [Table(nameof(HcimAccountTransfer))]

--- a/backend/webapi/Models/Lookups/AccessType.cs
+++ b/backend/webapi/Models/Lookups/AccessType.cs
@@ -1,0 +1,33 @@
+namespace Pidp.Models.Lookups;
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+public enum AccessTypeCode
+{
+    SAEforms = 1,
+    HcimAccountTransfer,
+    HcimEnrolment,
+    DriverFitness
+}
+
+// This table is only for reporting/database readability; it is not used by the FE or BE of the app.
+[Table("AccessTypeLookup")]
+public class AccessType
+{
+    [Key]
+    public AccessTypeCode Code { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+public class AccessTypeDataGenerator : ILookupDataGenerator<AccessType>
+{
+    public IEnumerable<AccessType> Generate() => new[]
+    {
+        new AccessType { Code = AccessTypeCode.SAEforms,            Name = "Special Authority eForms"},
+        new AccessType { Code = AccessTypeCode.HcimAccountTransfer, Name = "HCIMWeb Account Transfer"},
+        new AccessType { Code = AccessTypeCode.HcimEnrolment,       Name = "HCIMWeb Enrolment"       },
+        new AccessType { Code = AccessTypeCode.DriverFitness,       Name = "Driver Medical Fitness"  },
+    };
+}

--- a/workspace/apps/pidp/src/app/features/history/pages/transactions/transaction.model.ts
+++ b/workspace/apps/pidp/src/app/features/history/pages/transactions/transaction.model.ts
@@ -1,7 +1,7 @@
-import { AccessType } from '@bcgov/shared/data-access';
+import { AccessTypeCode } from '@bcgov/shared/data-access';
 
 export interface Transaction {
   partyId: number;
-  accessType: AccessType;
+  accessTypeCode: AccessTypeCode;
   requestedOn: string;
 }

--- a/workspace/apps/pidp/src/app/features/history/pages/transactions/transactions.page.html
+++ b/workspace/apps/pidp/src/app/features/history/pages/transactions/transactions.page.html
@@ -16,7 +16,7 @@
             <small>{{ transaction.requestedOn| formatDate }}</small>
             <small> {{ transaction.requestedOn | formatDate: 'h:mm a' }}</small>
           </span>
-          <span>{{ AccessTypeMap[transaction.accessType] }} submission</span>
+          <span>{{ AccessTypeMap[transaction.accessTypeCode] }} submission</span>
         </div>
       </ng-container>
     </ng-container>

--- a/workspace/libs/shared/data-access/src/lib/models/party.model.ts
+++ b/workspace/libs/shared/data-access/src/lib/models/party.model.ts
@@ -3,25 +3,26 @@ import { Facility } from './facility.model';
 import { PartyCertification } from './party-certification.model';
 import { User } from './user.model';
 
-export enum AccessType {
+export enum AccessTypeCode {
   SAEforms = 1,
   HcimAccountTransfer,
   HcimEnrolment,
   DriverFitness,
 }
 
-export const AccessTypeMap: { [AccessType: number]: string } = {
-  [AccessType.SAEforms]: 'Special Authority eForms',
-  [AccessType.HcimAccountTransfer]: 'HCIMWeb Account Transfer',
-  [AccessType.HcimEnrolment]: 'HCIMWeb Enrolment',
-  [AccessType.DriverFitness]: 'Driver Medical Fitness',
+// TODO use lookups
+export const AccessTypeMap: { [AccessTypeCode: number]: string } = {
+  [AccessTypeCode.SAEforms]: 'Special Authority eForms',
+  [AccessTypeCode.HcimAccountTransfer]: 'HCIMWeb Account Transfer',
+  [AccessTypeCode.HcimEnrolment]: 'HCIMWeb Enrolment',
+  [AccessTypeCode.DriverFitness]: 'Driver Medical Fitness',
 };
 
 export interface AccessRequest {
   id: number;
   partyId: number;
   requestedOn: string;
-  accessType: AccessType;
+  accessTypeCode: AccessTypeCode;
 }
 
 export interface Party extends User {


### PR DESCRIPTION
Adding a table just for the `AccessType` enum really stuck out like a sore thumb (and we probably should have it in the lookups properly anyways), so this ended up being a bit more than just adding a table.

The "Transactions" view in the FE should be updated in the future to actually use this lookup rather than being hard-coded.