### PR TITLE
Adding CSP script-src

### DIFF
--- a/charts/pidp/values.yaml
+++ b/charts/pidp/values.yaml
@@ -99,10 +99,11 @@ nginx:
       ssl_verify_client optional_no_ca;
       ssl_client_certificate certs/plr/trusted-ca-certs.pem;
 
-      set $CSP_style  "style-src    'self' 'unsafe-inline' *.googleapis.com *.gstatic.com; ";
-      set $CSP_font   "font-src     'self' data: *.googleapis.com *.gstatic.com; ";
+      set $CSP_style  "style-src    'self' 'unsafe-inline' *.googleapis.com *.gstatic.com https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css";
+      set $CSP_font   "font-src     'self' data: *.googleapis.com *.gstatic.com";
       set $CSP_frame  "frame-ancestors 'self'  *.oidc.gov.bc.ca oidc.gov.bc.ca";
-      set $CSP        "default-src  'self' ; ${CSP_style} ${CSP_font} ${CSP_frame}";
+      set $CSP_SCRIPT "script-src 'self' 'unsafe-inline' https://code.jquery.com/jquery-3.6.0.min.js";
+      set $CSP        "default-src  'self' ; ${CSP_style} ; ${CSP_font} ; ${CSP_SCRIPT} ; ${CSP_frame}";
 
       add_header Content-Security-Policy $CSP;
       add_header X-Frame-Options "ALLOW-FROM dev.oidc.gov.bc.ca oidc.gov.bc.ca" always;


### PR DESCRIPTION
Adding script-src CSP to whitelist https://code.jquery.com/jquery-3.6.0.min.js and adding https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css to stype-src 