### PR TITLE
Fix PLR Bug

### DIFF
--- a/backend/services.plr-intake/Features/Records/RecordsController.cs
+++ b/backend/services.plr-intake/Features/Records/RecordsController.cs
@@ -12,8 +12,8 @@ public class RecordsController : ControllerBase
                                                                   [FromQuery] Index.Query query)
         => await handler.HandleAsync(query);
 
-    [HttpPost("search")]
+    [HttpGet("cpns")]
     public async Task<ActionResult<List<string>>> SearchCpns([FromServices] IQueryHandler<Search.Query, List<string>> handler,
-                                                             [FromBody] Search.Query query)
+                                                             [FromQuery] Search.Query query)
         => await handler.HandleAsync(query);
 }

--- a/backend/webapi/Extensions/LocalDateExtensions.cs
+++ b/backend/webapi/Extensions/LocalDateExtensions.cs
@@ -1,0 +1,13 @@
+namespace Pidp.Extensions;
+
+using NodaTime;
+using System.Globalization;
+
+public static class LocalDateExtensions
+{
+    /// <summary>
+    /// Formats the LocalDate as an ISO date string, i.e. "yyyy-MM-dd".
+    /// </summary>
+    /// <param name="date"></param>
+    public static string ToIsoDateString(this LocalDate date) => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}


### PR DESCRIPTION
So it turns out that there are date formats that C# is happy to coerce into `DateTime`s that JSON cannot de-serialize into. 
So when I changed the PLR API to be a `POST` with a body rather than a `GET` with query strings, license look-up broke when we try to send the birthdate.