### PR TITLE
Small updates to DMFT API metadata

### DIFF
--- a/backend/webapi/Features/ThirdPartyIntegrations/ThirdPartyintegrationsController.cs
+++ b/backend/webapi/Features/ThirdPartyIntegrations/ThirdPartyintegrationsController.cs
@@ -6,13 +6,17 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Pidp.Infrastructure.Auth;
+using Pidp.Infrastructure.Services;
 
 [Route("api/ext")]
-public class ThirdPartyintegrationsController : ControllerBase
+public class ThirdPartyintegrationsController : PidpControllerBase
 {
+    public ThirdPartyintegrationsController(IPidpAuthorizationService authorizationService) : base(authorizationService) { }
+
     [HttpGet("parties/{hpdid}/endorsements")]
     [Authorize(Roles = Roles.ViewEndorsements)]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<List<EndorsementData.Model>>> GetEndorsemetData([FromServices] IQueryHandler<EndorsementData.Query, IDomainResult<List<EndorsementData.Model>>> handler,
                                                                                    [FromRoute] EndorsementData.Query query)


### PR DESCRIPTION
I had originally made this controller inherit from `ControllerBase` (the default ASP.NET base class) for simplicity.
But I forgot to set the media type to `application/json` and set the `[ApiController]` Attribute.
Soooo in order to not forget, I've decided its better to stick to the convention.