### PR TITLE
PIDP-461 - Better PLR Matching

### DIFF
--- a/backend/services.plr-intake.tests/Features/Records/Search.cs
+++ b/backend/services.plr-intake.tests/Features/Records/Search.cs
@@ -13,27 +13,31 @@ public class SearchTests : InMemoryDbTest
     {
         var record = this.TestDb.Has(new PlrRecord
         {
-            Ipc = "IPC1",
             Cpn = "CPN",
             IdentifierType = "CPSID",
             CollegeId = "12345",
-            ProviderRoleType = "ProviderRoleType",
-            StatusCode = "StatusCode",
-            StatusStartDate = DateTime.Today,
-            StatusReasonCode = "StatusReasonCode",
             DateOfBirth = DateTime.Today
         });
-        this.TestDb.Has(new PlrRecord
+        this.TestDb.HasSome(new PlrRecord
         {
-            Ipc = "DECOY",
-            Cpn = "DECOYCPN",
-            IdentifierType = "CPSID",
+            Cpn = "DecoyIdentifier",
+            IdentifierType = "PHID",
+            CollegeId = record.CollegeId,
+            DateOfBirth = record.DateOfBirth
+        },
+        new PlrRecord
+        {
+            Cpn = "DecoyId",
+            IdentifierType = record.IdentifierType,
             CollegeId = "52345",
-            ProviderRoleType = "DecoyProviderRoleType",
-            StatusCode = "DecoyStatusCode",
-            StatusStartDate = DateTime.Today,
-            StatusReasonCode = "DecoyStatusReasonCode",
-            DateOfBirth = DateTime.Today
+            DateOfBirth = record.DateOfBirth
+        },
+        new PlrRecord
+        {
+            Cpn = "DecoyBirthdate",
+            IdentifierType = record.IdentifierType,
+            CollegeId = record.CollegeId,
+            DateOfBirth = record.DateOfBirth!.Value.AddDays(1)
         });
         var query = new Search.Query
         {
@@ -56,14 +60,9 @@ public class SearchTests : InMemoryDbTest
     {
         var record = this.TestDb.Has(new PlrRecord
         {
-            Ipc = "IPC1",
             Cpn = "CPN",
             IdentifierType = "CPSID",
             CollegeId = dbId,
-            ProviderRoleType = "ProviderRoleType",
-            StatusCode = "StatusCode",
-            StatusStartDate = DateTime.Today,
-            StatusReasonCode = "StatusReasonCode",
             DateOfBirth = DateTime.Today
         });
         var query = new Search.Query
@@ -108,14 +107,9 @@ public class SearchTests : InMemoryDbTest
     {
         var record = this.TestDb.Has(new PlrRecord
         {
-            Ipc = "IPC1",
             Cpn = "CPN",
             IdentifierType = "CPSID",
             CollegeId = dbId,
-            ProviderRoleType = "ProviderRoleType",
-            StatusCode = "StatusCode",
-            StatusStartDate = DateTime.Today,
-            StatusReasonCode = "StatusReasonCode",
             DateOfBirth = DateTime.Today
         });
         var query = new Search.Query

--- a/backend/services.plr-intake.tests/Testing Extensions/ContextExtensions.cs
+++ b/backend/services.plr-intake.tests/Testing Extensions/ContextExtensions.cs
@@ -17,4 +17,6 @@ public static class ContextExtensions
         context.SaveChanges();
         return things;
     }
+
+    public static IEnumerable<T> HasSome<T>(this PlrDbContext context, params T[] things) => HasSome(context, things.AsEnumerable());
 }

--- a/backend/services.plr-intake/Data/PlrDbContext.cs
+++ b/backend/services.plr-intake/Data/PlrDbContext.cs
@@ -40,10 +40,8 @@ public class PlrDbContext : DbContext
 
     private void ApplyAudits()
     {
-        this.ChangeTracker.DetectChanges();
-        var updated = this.ChangeTracker.Entries()
-            .Where(x => x.Entity is BaseAuditable
-                && (x.State == EntityState.Added || x.State == EntityState.Modified));
+        var updated = this.ChangeTracker.Entries<BaseAuditable>()
+            .Where(x => x.State is EntityState.Added or EntityState.Modified);
 
         var currentInstant = DateTime.Now;
 

--- a/backend/services.plr-intake/Features/Records/Search.cs
+++ b/backend/services.plr-intake/Features/Records/Search.cs
@@ -34,9 +34,13 @@ public class Search
 
         public async Task<List<string>> HandleAsync(Query query)
         {
+            var paddedId = query.CollegeId
+                .PadLeft(5, '0')
+                [^5..];
+
             return await this.context.PlrRecords
                 .ExcludeDeleted()
-                .Where(record => record.CollegeId!.TrimStart('0') == query.CollegeId.TrimStart('0')
+                .Where(record => record.CollegeId!.PadLeft(5, '0').EndsWith(paddedId)
                     && record.DateOfBirth!.Value.Date == query.Birthdate.Date
                     && query.IdentifierTypes.Contains(record.IdentifierType!))
                 .Select(record => record.Cpn!) // All valid PLR records will have CPNs


### PR DESCRIPTION
The PLR license search now looks at the last 5 digits of the licence number only (as well as trimming leading zeros).
This applies to both the number the user enters as well as the number in PLR.