### PR TITLE
PIDP-592 - MOA Role logic in AAD

### DIFF
--- a/backend/webapi/Features/EndorsementRequests/Approve.cs
+++ b/backend/webapi/Features/EndorsementRequests/Approve.cs
@@ -120,15 +120,16 @@ public class Approve
             if (await this.keycloakClient.AssignAccessRoles(unLicencedParty.UserId, MohKeycloakEnrolment.MoaLicenceStatus))
             {
                 this.context.BusinessEvents.Add(LicenceStatusRoleAssigned.Create(unLicencedParty.Id, MohKeycloakEnrolment.MoaLicenceStatus, this.clock.GetCurrentInstant()));
-                if (!string.IsNullOrWhiteSpace(unLicencedParty.UserPrincipalName))
-                {
-                    var endorseeBcProviderAttributes = new BCProviderAttributes(this.config.BCProviderClient.ClientId).SetIsMoa(true);
-                    await this.bcProviderClient.UpdateAttributes(unLicencedParty.UserPrincipalName, endorseeBcProviderAttributes.AsAdditionalData());
-                }
             }
             else
             {
                 this.logger.LogMoaRoleAssignmentError(unLicencedParty.Id);
+            }
+
+            if (!string.IsNullOrWhiteSpace(unLicencedParty.UserPrincipalName))
+            {
+                var endorseeBcProviderAttributes = new BCProviderAttributes(this.config.BCProviderClient.ClientId).SetIsMoa(true);
+                await this.bcProviderClient.UpdateAttributes(unLicencedParty.UserPrincipalName, endorseeBcProviderAttributes.AsAdditionalData());
             }
         }
     }

--- a/backend/webapi/Models/BusinessEvent.cs
+++ b/backend/webapi/Models/BusinessEvent.cs
@@ -52,3 +52,21 @@ public class LicenceStatusRoleAssigned : BusinessEvent
         };
     }
 }
+
+public class LicenceStatusRoleUnassigned : BusinessEvent
+{
+    public int PartyId { get; set; }
+    public Party? Party { get; set; }
+
+    public static LicenceStatusRoleUnassigned Create(int partyId, MohKeycloakEnrolment enrolmentAssigned, Instant recordedOn)
+    {
+        return new LicenceStatusRoleUnassigned
+        {
+            PartyId = partyId,
+            Description = $"Party was unassigned the {enrolmentAssigned.AccessRoles.Single()} role.",
+            Severity = LogLevel.Information,
+            RecordedOn = recordedOn
+        };
+    }
+}
+


### PR DESCRIPTION
Add or remove the MOA flag to AAD when :
- Removes the MOA flag when the endorsement is cancelled and the MOA has no endorsements for licenced professionals in active standing.
- Adds the MOA flag when the user is unregulated and becomes endorsed by a regulated user in good standing.
