### PR TITLE
Local docker image for RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - pidp-net
 
   ###############################################################################
-  ###                     PIdP API Backend Definition                         ###
+  ###                       PIdP API Backend Definition                       ###
   ###############################################################################
   pidp-webapi:
     container_name: pidp-webapi
@@ -67,7 +67,7 @@ services:
     ]
 
   ###############################################################################
-  ###                        PLR Intake Definition                            ###
+  ###                          PLR Intake Definition                          ###
   ###############################################################################
   pidp-plr-intake:
     container_name: pidp-plr-intake
@@ -108,7 +108,23 @@ services:
     ]
 
   ###############################################################################
-  ###                                Mailhog                                  ###
+  ###                                RabbitMQ                                 ###
+  ###############################################################################
+  pidp-rabbitmq:
+    container_name: 'pidp-rabbitmq'
+    restart: always
+    image: rabbitmq:3-management-alpine
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    ports:
+      - 5672:5672
+      - 15672:15672
+    networks:
+      - pidp-net
+
+  ###############################################################################
+  ###                                 Mailhog                                 ###
   ###############################################################################
   mailhog:
     container_name: mailhog
@@ -147,7 +163,7 @@ networks:
     driver: bridge
 
 ###############################################################################
-###                            Volumes Definition                           ###
+###                           Volumes Definition                            ###
 ###############################################################################
 volumes:
   local_pidp_postgress_data: null


### PR DESCRIPTION
RabbitMQ official docker images and documentation https://hub.docker.com/_/rabbitmq
### Image
The image used `rabbitmq:3-management-alpine`:
- version 3.* of RabbitMQ
- with the "RabbitMQ management" interface accessible locally from the URL http://localhost:15672/
- Alpine is the lightest and most secure Linux distribution for RabbitMQ

### Default user and password
Setting default user and password with the default value `guest:guest`
Could be changed or removed.

### Ports
- Port 5672 used by AMQP (Advanced Message Queuing Protocol)
- Port 15672 used by `RabbitMQ management` UI
Official documentation: https://www.rabbitmq.com/networking.html#ports