### PR TITLE
UAA text update 3

### DIFF
--- a/workspace/apps/pidp/src/app/features/profile/pages/user-access-agreement/components/user-access-agreement-document/user-access-agreement-document.component.html
+++ b/workspace/apps/pidp/src/app/features/profile/pages/user-access-agreement/components/user-access-agreement-document/user-access-agreement-document.component.html
@@ -72,7 +72,7 @@
     <p>
       To only access the System(s) for so long as I am a registrant in good
       standing with my Professional College and my registration permits me to
-      deliver direct patient care.
+      deliver patient care.
     </p>
     <p>
       For Supervised Users Accessing System(s) on behalf of a College


### PR DESCRIPTION
```
Hello, 

Sorry for the short the last minute email, but there’s one final text change for the UAA. 

User Access Agreement 3.0
1.	For Providers registered with a Professional College in BC: 
1.	To only access the System(s) for so long as I am a registrant in good standing with my Professional College and my registration permits me to deliver direct patient care. 
Please delete the word direct.

Thank you!
```