### PR TITLE
Fix - Only perform call when bcprovider has been created

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/portal.page.ts
+++ b/workspace/apps/pidp/src/app/features/portal/portal.page.ts
@@ -179,18 +179,17 @@ export class PortalPage implements OnInit {
         this.bcProviderStatusCode = profileStatus?.status.bcProvider.statusCode;
         if (this.bcProviderStatusCode === 2) {
           this.bcProvider$.next(true);
+          this.bcProviderResource
+            .get(this.partyService.partyId)
+            .subscribe((bcProviderObject: BcProviderEditInitialStateModel) => {
+              this.bcProviderUsername = bcProviderObject.bcProviderId;
+            });
         }
         this.rosteringStatusCode =
           profileStatus?.status.primaryCareRostering.statusCode;
         if (this.rosteringStatusCode === 1) {
           this.rostering$.next(false);
         }
-      });
-
-    this.bcProviderResource
-      .get(this.partyService.partyId)
-      .subscribe((bcProviderObject: BcProviderEditInitialStateModel) => {
-        this.bcProviderUsername = bcProviderObject.bcProviderId;
       });
   }
 


### PR DESCRIPTION
When a user hadnt signed up for BCProvider yet, there was a console error when landing on Portal page which was trying to populate the BCProvider username. 