### PR TITLE
Fix - Wizard initialized with the last step opened

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/portal.page.ts
+++ b/workspace/apps/pidp/src/app/features/portal/portal.page.ts
@@ -100,7 +100,7 @@ export class PortalPage implements OnInit {
     this.uaaTutorial = uaaTutorialLink;
     this.bcProviderTutorial = bcProviderTutorialLink;
     this.lastSelectedIndex = 6;
-    this.selectedIndex = this.lastSelectedIndex;
+    this.selectedIndex = -1;
   }
 
   public navigateTo(): void {


### PR DESCRIPTION
Initialized `selectedIndex` step on a non-existent index.