### PR TITLE
Fix the title positioned underneath the header after scrolling to the anchor.

### DIFF
--- a/workspace/apps/pidp/src/scss/app.scss
+++ b/workspace/apps/pidp/src/scss/app.scss
@@ -70,3 +70,7 @@
 // Vendors is used to include customized vendor styles into the
 // application.
 @import './vendors/vendors';
+
+* {
+  scroll-margin-top: 43px;
+}


### PR DESCRIPTION
Fix the title positioned underneath the header after scrolling to the anchor.

solution:
https://stackoverflow.com/questions/13614112/using-scrollintoview-with-a-fixed-position-header