### PR TITLE
Fix pr number

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -29,7 +29,6 @@ concurrency:
 jobs:
 
   get-pr-number:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,8 +41,10 @@ jobs:
       
       - id: step1 
         name: Returns empty if its the initial push
-        run: |
-          echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_OUTPUT"
+        if: github.event_name == 'push'
+        run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_OUTPUT"
+        if: github.event_name == 'pull_request'
+        run: echo "pr_number=${{ github.event.number }}" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -35,21 +35,24 @@ jobs:
         working-directory: "./workspace"
 
     outputs:
-      pr_number: ${{ steps.step1.outputs.pr_number }}
+      pr_number: ${{ steps.find-pr.outputs.pr }}
 
     steps:
       - name: "Checkout Code"
         uses: actions/checkout@master
       
-      - id: step1 
-        name: Returns empty if its the initial push
-        if: github.event_name == 'push'
-        run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_OUTPUT"
-        if: github.event_name == 'pull_request'
-        run: echo "pr_number=${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+      - name: find-pr
+        id: find-pr
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          state: open
 
+      - name: job1
+        id: job1
+        run: echo "Your PR is ${PR}"
+        if: success() && steps.find-pr.outputs.number
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.find-pr.outputs.pr }}
 
 
   build-and-deploy-frontend:
@@ -84,25 +87,9 @@ jobs:
 
 
       - name: Get pr number from GH cli command (pushing to pr)
-        if: ${{ github.event.number == ''}}
-        # TODO: In some cases this action produces an incorrect pr number. eg: it results in 319 when the PR triggering the action is #324.
-        # TODO: This event has been triggered on an opening of a pr. both the "pushing on pr" and "opening a pr" needs to be further investigated. The if condition isn't always a valid test.
-        run: |
-          echo " github.event.number = ${{ github.event.number == ''}}"
-          echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_ENV"
-          echo " pr_number = ${{ env.pr_number }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          :pr_number: ${{ needs.get-pr-number.outputs.pr_number }}
 
-
-      - name: Get pr number from github.event.number (opening a pr)
-        if: ${{ github.event.number != ''}}
-        run: |
-          echo " github.event.number = ${{ github.event.number == ''}}"
-          echo "pr_number=${{ github.event.number }}" >> "$GITHUB_ENV"
-          echo " pr_number = ${{ env.pr_number }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
       - name: "Docker Build"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -28,9 +28,23 @@ concurrency:
 
 jobs:
 
+  get-pr-number:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      initial_push: ${{ steps.step1.outputs.initial_push }}
+    steps:
+      - id: step1 
+        name: Returns true if its not the initial push
+        if: ${{ github.event.pull_request.number == ''}}
+        run: |
+          echo "::set-output name=initial_push::false"
+
+
   build-and-deploy-frontend:
     name: Frontend Build and Deploy
     runs-on: ubuntu-latest
+    
     defaults:
       run:
         working-directory: "./workspace"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -29,11 +29,8 @@ concurrency:
 jobs:
 
   get-pr-number:
-    if: github.event_name == 'push'
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: "./workspace"
     outputs:
       initial_push: ${{ steps.step1.outputs.pr_number }}
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -31,9 +31,20 @@ jobs:
   get-pr-number:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: "./workspace"
     outputs:
       initial_push: ${{ steps.step1.outputs.pr_number }}
     steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@master
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      
       - id: step1 
         name: Returns empty if its the initial push
         run: |

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -38,13 +38,14 @@ jobs:
         name: Returns true if its not the initial push
         if: ${{ github.event.pull_request.number == ''}}
         run: |
-          echo "::set-output name=initial_push::false"
+          echo "initial_push=false" >> $GITHUB_OUTPUT
 
 
   build-and-deploy-frontend:
     name: Frontend Build and Deploy
     runs-on: ubuntu-latest
-    
+    needs: get-pr-number
+    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.initial_push == 'false' }}
     defaults:
       run:
         working-directory: "./workspace"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -31,6 +31,9 @@ jobs:
   get-pr-number:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: "./workspace"
     outputs:
       initial_push: ${{ steps.step1.outputs.pr_number }}
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -33,8 +33,10 @@ jobs:
     defaults:
       run:
         working-directory: "./workspace"
+
     outputs:
       pr_number: ${{ steps.step1.outputs.pr_number }}
+
     steps:
       - name: "Checkout Code"
         uses: actions/checkout@master
@@ -45,6 +47,7 @@ jobs:
         run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_OUTPUT"
         if: github.event_name == 'pull_request'
         run: echo "pr_number=${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,7 +165,6 @@ jobs:
       - name: "Push image"
         run: |
           docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-plr-intake:pr-${{ env.pr_number }}
-
 
   build-and-deploy-webapi:
     name: WebAPI Backend Build and Deploy

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -38,6 +38,8 @@ jobs:
         name: Returns empty if its the initial push
         run: |
           echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
   build-and-deploy-frontend:
@@ -112,6 +114,8 @@ jobs:
 
   build-and-deploy-plr-intake:
     name: PLR Intake Backend Build and Deploy
+    needs: get-pr-number
+    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.pr_number != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -155,6 +159,8 @@ jobs:
 
   build-and-deploy-webapi:
     name: WebAPI Backend Build and Deploy
+    needs: get-pr-number
+    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.pr_number != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -14,16 +14,10 @@ on:
     - 'test'
     - 'main'
   pull_request:
-    # paths:
-    #   - "workspace/**"
-    #   - "backend/services.plr-intake/**"
-    #   - "backend/services.plr-intake.tests/**"
-    #   - "backend/webapi/**"
-    #   - "backend/webapi.tests/**"
+    types: [opened]
     branches-ignore:
-    - 'develop'
-    - 'test'
-    - 'main'
+      - 'test'
+      - 'master'
 
 permissions: read-all
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Frontend Build and Deploy
     runs-on: ubuntu-latest
     needs: get-pr-number
-    if: ${{ needs.get-pr-number.outputs.pr_number != '' }}
+    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.pr_number != '' }}
     defaults:
       run:
         working-directory: "./workspace"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: "Docker Build"
         run: |
-          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr- ${{ needs.get-pr-number.outputs.pr_number }} .
+          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr-${{ needs.get-pr-number.outputs.pr_number }} .
 
       # Uses the builder service account token
       - name: "Docker Login to Silver OCP"
@@ -100,7 +100,7 @@ jobs:
 
       - name: "Push image"
         run: |
-          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr- ${{ needs.get-pr-number.outputs.pr_number }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr-${{ needs.get-pr-number.outputs.pr_number }}
 
 
   build-and-deploy-plr-intake:
@@ -119,21 +119,9 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@master
 
-      - name: Get pr number from GH cli command (pushing to pr)
-        if: ${{ github.event.number == ''}}
-        run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get pr number from github.event.number (opening a pr)
-        if: ${{ github.event.number != ''}}
-        run: echo "pr_number=${{ github.event.number }}" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: "Docker Build"
         run: |
-          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-plr-intake:pr-${{ env.pr_number }} .
+          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-plr-intake:pr-${{ needs.get-pr-number.outputs.pr_number }} .
 
       # Uses the builder service account token
       - name: "Docker Login to Silver OCP"
@@ -145,7 +133,7 @@ jobs:
 
       - name: "Push image"
         run: |
-          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-plr-intake:pr-${{ env.pr_number }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-plr-intake:pr-${{ needs.get-pr-number.outputs.pr_number }}
 
   build-and-deploy-webapi:
     name: WebAPI Backend Build and Deploy
@@ -163,22 +151,9 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@master
 
-      - name: Get pr number from GH cli command (pushing to pr)
-        if: ${{ github.event.number == ''}}
-        run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-      - name: Get pr number from github.event.number (opening a pr)
-        if: ${{ github.event.number != ''}}
-        run: echo "pr_number=${{ github.event.number }}" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: "Docker Build"
         run: |
-          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-webapi:pr-${{ env.pr_number }} .
+          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-webapi:pr-${{ needs.get-pr-number.outputs.pr_number }} .
 
       # Uses the builder service account token
       - name: "Docker Login to Silver OCP"
@@ -190,7 +165,7 @@ jobs:
 
       - name: "Push image"
         run: |
-          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-webapi:pr-${{ env.pr_number }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-webapi:pr-${{ needs.get-pr-number.outputs.pr_number }}
 
   helm-deployment:
     needs: [build-and-deploy-webapi, build-and-deploy-plr-intake, build-and-deploy-frontend]

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -37,7 +37,7 @@ jobs:
       - id: step1 
         name: Returns empty if its the initial push
         run: |
-          echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
+          echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
 
   get-pr-number:
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,11 +39,6 @@ jobs:
     steps:
       - name: "Checkout Code"
         uses: actions/checkout@master
-
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       
       - id: step1 
         name: Returns empty if its the initial push
@@ -57,7 +52,7 @@ jobs:
     name: Frontend Build and Deploy
     runs-on: ubuntu-latest
     needs: get-pr-number
-    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.pr_number != '' }}
+    if: ${{ needs.get-pr-number.outputs.pr_number != '' }}
     defaults:
       run:
         working-directory: "./workspace"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -32,20 +32,19 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
-      initial_push: ${{ steps.step1.outputs.initial_push }}
+      initial_push: ${{ steps.step1.outputs.pr_number }}
     steps:
       - id: step1 
-        name: Returns true if its not the initial push
-        if: ${{ github.event.pull_request.number == ''}}
+        name: Returns empty if its the initial push
         run: |
-          echo "initial_push=false" >> $GITHUB_OUTPUT
+          echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
 
 
   build-and-deploy-frontend:
     name: Frontend Build and Deploy
     runs-on: ubuntu-latest
     needs: get-pr-number
-    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.initial_push == 'false' }}
+    if: ${{ always() && !cancelled() && needs.get-pr-number.outputs.pr_number != '' }}
     defaults:
       run:
         working-directory: "./workspace"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -35,7 +35,7 @@ jobs:
       run:
         working-directory: "./workspace"
     outputs:
-      initial_push: ${{ steps.step1.outputs.pr_number }}
+      pr_number: ${{ steps.step1.outputs.pr_number }}
     steps:
       - name: "Checkout Code"
         uses: actions/checkout@master

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -86,15 +86,9 @@ jobs:
           yarn build
 
 
-      - name: Get pr number from GH cli command (pushing to pr)
-        env:
-          :pr_number: ${{ needs.get-pr-number.outputs.pr_number }}
-
-
-
       - name: "Docker Build"
         run: |
-          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr-${{ env.pr_number }} .
+          docker build -t image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr- ${{ needs.get-pr-number.outputs.pr_number }} .
 
       # Uses the builder service account token
       - name: "Docker Login to Silver OCP"
@@ -106,7 +100,7 @@ jobs:
 
       - name: "Push image"
         run: |
-          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr-${{ env.pr_number }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/d8a8f9-tools/pidp-frontend:pr- ${{ needs.get-pr-number.outputs.pr_number }}
 
 
   build-and-deploy-plr-intake:


### PR DESCRIPTION
A new job called "get-pr-number" was added. The PR number is equal to github.event.number when opening a PR and its equal to gh pr when pushing to PR. Other jobs have dependency to "get-pr-number"  job