### PR TITLE
Fix middle preferred name

### DIFF
--- a/workspace/libs/shared/ui/src/lib/directives/trim.directive.spec.ts
+++ b/workspace/libs/shared/ui/src/lib/directives/trim.directive.spec.ts
@@ -79,4 +79,19 @@ describe('TrimDirective', () => {
       expect(formControl.value).toBe('test');
     });
   });
+
+  it('should set ngControl value to null if the value is an empty string', () => {
+    const nativeElement = des[1].nativeElement;
+    nativeElement.value = '';
+    expect(nativeElement.value).toBe('');
+
+    const inputEvent = new InputEvent('blur');
+    nativeElement.dispatchEvent(inputEvent);
+
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      const formControl = fixture.componentInstance.form.controls.name;
+      expect(formControl.value).toBe(null);
+    });
+  });
 });

--- a/workspace/libs/shared/ui/src/lib/directives/trim.directive.ts
+++ b/workspace/libs/shared/ui/src/lib/directives/trim.directive.ts
@@ -12,10 +12,12 @@ export class TrimDirective {
   ) {}
 
   @HostListener('blur') public onBlur(): void {
+    let value: string | null = this.el.nativeElement.value.trim();
     if (this.ngControl?.control) {
-      this.ngControl.control.setValue(this.el.nativeElement.value.trim());
+      value = value === '' ? null : value;
+      this.ngControl.control.setValue(value);
     } else {
-      this.el.nativeElement.value = this.el.nativeElement.value.trim();
+      this.el.nativeElement.value = value;
     }
   }
 }


### PR DESCRIPTION
The backend accepts only a null value or a non-empty string but if the user clicks on the preferred middle name text box an empty value is set and the form can't be saved.