### PR TITLE
Fix - Endorsements card availability

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/state/organization/endorsements-portal-section.class.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/organization/endorsements-portal-section.class.ts
@@ -20,7 +20,7 @@ export class EndorsementsPortalSection implements IPortalSection {
 
   public constructor(
     private profileStatus: ProfileStatus,
-    private router: Router
+    private router: Router,
   ) {
     this.key = 'endorsements';
     this.heading = 'Endorsements';
@@ -40,14 +40,11 @@ export class EndorsementsPortalSection implements IPortalSection {
     return {
       label: 'View',
       route: OrganizationInfoRoutes.routePath(
-        OrganizationInfoRoutes.ENDORSEMENTS
+        OrganizationInfoRoutes.ENDORSEMENTS,
       ),
-      disabled: !(
-        this.profileStatus.status.demographics.statusCode ===
-          StatusCode.COMPLETED &&
-        this.profileStatus.status.collegeCertification.statusCode ===
-          StatusCode.COMPLETED
-      ),
+      disabled:
+        this.profileStatus.status.endorsements.statusCode ===
+        StatusCode.NOT_AVAILABLE,
     };
   }
 


### PR DESCRIPTION
- Show / lock endorsements card based on LOCKED status that gets calculated in the backend. This was noticed because a licenced individual losing their licence to a bad standing plr status change, also locked the user out of endorsements card.