### PR TITLE
PIDP-493 - Dotnet 8

### DIFF
--- a/backend/pidp-backend.sln
+++ b/backend/pidp-backend.sln
@@ -1,11 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pidp", "webapi\pidp.csproj", "{690CB0B5-518B-443E-9E5C-B5A63A3F9E13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pidp", "webapi\pidp.csproj", "{690CB0B5-518B-443E-9E5C-B5A63A3F9E13}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pidp.tests", "webapi.tests\pidp.tests.csproj", "{BC7BAF1F-4C48-4DB2-A704-EBB4DD2CFBFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pidp.tests", "webapi.tests\pidp.tests.csproj", "{BC7BAF1F-4C48-4DB2-A704-EBB4DD2CFBFA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plr-intake", "services.plr-intake\plr-intake.csproj", "{8682A94E-4E90-4846-A7E8-E4CECB55DF79}"
 EndProject

--- a/backend/pidp-backend.sln
+++ b/backend/pidp-backend.sln
@@ -15,7 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endorsement-reminder", "ser
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endorsement-reminder.tests", "services.endorsement-reminder.tests\endorsement-reminder.tests.csproj", "{1251BD7F-30CB-4333-87D3-A96912F86361}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "do-work", "tools.do-work\do-work.csproj", "{631ECF6D-6E61-49EF-933B-B9423A068032}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "do-work", "tools.do-work\do-work.csproj", "{631ECF6D-6E61-49EF-933B-B9423A068032}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/backend/pidp-backend.sln
+++ b/backend/pidp-backend.sln
@@ -11,9 +11,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plr-intake", "services.plr-
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plr-intake.tests", "services.plr-intake.tests\plr-intake.tests.csproj", "{6C64ACF9-73DD-4A52-926E-9AFC07555060}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "endorsement-reminder", "services.endorsement-reminder\endorsement-reminder.csproj", "{BBEAD4F7-BD9E-43F9-8AAD-D11FE22451E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endorsement-reminder", "services.endorsement-reminder\endorsement-reminder.csproj", "{BBEAD4F7-BD9E-43F9-8AAD-D11FE22451E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "endorsement-reminder.tests", "services.endorsement-reminder.tests\endorsement-reminder.tests.csproj", "{1251BD7F-30CB-4333-87D3-A96912F86361}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endorsement-reminder.tests", "services.endorsement-reminder.tests\endorsement-reminder.tests.csproj", "{1251BD7F-30CB-4333-87D3-A96912F86361}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "do-work", "tools.do-work\do-work.csproj", "{631ECF6D-6E61-49EF-933B-B9423A068032}"
 EndProject

--- a/backend/services.endorsement-reminder.tests/endorsement-reminder.tests.csproj
+++ b/backend/services.endorsement-reminder.tests/endorsement-reminder.tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <RootNamespace>EndorsementReminderTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NodaTime" Version="3.1.6" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FakeItEasy" Version="8.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\services.endorsement-reminder\endorsement-reminder.csproj" />

--- a/backend/services.endorsement-reminder/Dockerfile
+++ b/backend/services.endorsement-reminder/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine as build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine as build-env
 WORKDIR /source
 
 ENV DOTNET_CLI_HOME="/opt"
@@ -10,7 +10,7 @@ COPY ../webapi ./webapi
 RUN dotnet publish services.endorsement-reminder/endorsement-reminder.csproj -c Release -o /app -r linux-musl-x64 --self-contained false
 
 #----------------------------------------------------------------#
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 WORKDIR /app
 
 COPY --from=build-env /app .

--- a/backend/services.endorsement-reminder/endorsement-reminder.csproj
+++ b/backend/services.endorsement-reminder/endorsement-reminder.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>EndorsementReminder</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -12,6 +11,6 @@
     <ProjectReference Include="..\webapi\pidp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.6" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
   </ItemGroup>
 </Project>

--- a/backend/tools.do-work/do-work.csproj
+++ b/backend/tools.do-work/do-work.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>DoWork</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -15,5 +14,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/backend/tools.plr-test-data/.vscode/launch.json
+++ b/backend/tools.plr-test-data/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/bin/Debug/net6.0/plr-test-data.dll",
+      "program": "${workspaceFolder}/bin/Debug/net8.0/plr-test-data.dll",
       "args": [],
       "cwd": "${workspaceFolder}",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/backend/tools.plr-test-data/plr-test-data.csproj
+++ b/backend/tools.plr-test-data/plr-test-data.csproj
@@ -2,11 +2,10 @@
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlrTestData</RootNamespace>
-
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>plr-test-data</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/backend/webapi.tests/.vscode/launch.json
+++ b/backend/webapi.tests/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net6.0/pidp.tests.dll",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/pidp.tests.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/backend/webapi.tests/pidp.tests.csproj
+++ b/backend/webapi.tests/pidp.tests.csproj
@@ -7,17 +7,17 @@
     <RootNamespace>PidpTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FakeItEasy" Version="8.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NodaTime" Version="3.1.6" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\webapi\pidp.csproj" />

--- a/backend/webapi.tests/pidp.tests.csproj
+++ b/backend/webapi.tests/pidp.tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -10,9 +10,9 @@
     <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NodaTime" Version="3.1.6" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/backend/webapi/.vscode/launch.json
+++ b/backend/webapi/.vscode/launch.json
@@ -9,7 +9,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/bin/Debug/net6.0/pidp.dll",
+      "program": "${workspaceFolder}/bin/Debug/net8.0/pidp.dll",
       "args": [],
       "cwd": "${workspaceFolder}",
       "stopAtEntry": false,

--- a/backend/webapi/Data/Migrations/20240527105030_DotNet8Upgrade.Designer.cs
+++ b/backend/webapi/Data/Migrations/20240527105030_DotNet8Upgrade.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Pidp.Data;
 namespace Pidp.Data.Migrations
 {
     [DbContext(typeof(PidpDbContext))]
-    partial class PidpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240527105030_DotNet8Upgrade")]
+    partial class DotNet8Upgrade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/webapi/Data/Migrations/20240527105030_DotNet8Upgrade.cs
+++ b/backend/webapi/Data/Migrations/20240527105030_DotNet8Upgrade.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pidp.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DotNet8Upgrade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                table: "BusinessEvent",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                table: "Address",
+                type: "character varying(21)",
+                maxLength: 21,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                table: "BusinessEvent",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(34)",
+                oldMaxLength: 34);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                table: "Address",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(21)",
+                oldMaxLength: 21);
+        }
+    }
+}

--- a/backend/webapi/Data/PidpDbContext.cs
+++ b/backend/webapi/Data/PidpDbContext.cs
@@ -99,6 +99,6 @@ public class PidpDbContext : DbContext
     }
 
     // Uncomment for SQL logging
-    // protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    //     => optionsBuilder.LogTo(Console.WriteLine);
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.LogTo(Console.WriteLine);
 }

--- a/backend/webapi/Data/PidpDbContext.cs
+++ b/backend/webapi/Data/PidpDbContext.cs
@@ -99,6 +99,6 @@ public class PidpDbContext : DbContext
     }
 
     // Uncomment for SQL logging
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.LogTo(Console.WriteLine);
+    // protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    //     => optionsBuilder.LogTo(Console.WriteLine);
 }

--- a/backend/webapi/Dockerfile
+++ b/backend/webapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine as build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine as build-env
 WORKDIR /source
 
 ENV DOTNET_CLI_HOME="/opt"
@@ -15,7 +15,7 @@ RUN dotnet publish -c Release -o /app -r linux-musl-x64 --self-contained false -
 RUN dotnet ef migrations bundle
 
 #----------------------------------------------------------------#
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 WORKDIR /app
 
 ENV ASPNETCORE_ENVIRONMENT="Production"

--- a/backend/webapi/Dockerfile
+++ b/backend/webapi/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /source
 ENV DOTNET_CLI_HOME="/opt"
 ENV PATH="$PATH:/opt/.dotnet/tools"
 
-RUN dotnet tool install --global dotnet-ef --version "7.*"
+RUN dotnet tool install --global dotnet-ef --version "8.*"
 
 COPY *.csproj .
 RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
@@ -32,7 +32,6 @@ COPY --from=build-env /source/efbundle .
 
 RUN cd /app && mkdir -p logs \
     chmod 755 /app/logs/
-
 
 EXPOSE 8080
 

--- a/backend/webapi/Dockerfile.local
+++ b/backend/webapi/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /vsdbg
 

--- a/backend/webapi/Dockerfile.local
+++ b/backend/webapi/Dockerfile.local
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /vsdbg
 
-RUN dotnet tool install --global dotnet-ef --version 6
+RUN dotnet tool install --global dotnet-ef --version "8.*"
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1

--- a/backend/webapi/Infrastructure/Auth/AuthenticationSetup.cs
+++ b/backend/webapi/Infrastructure/Auth/AuthenticationSetup.cs
@@ -3,7 +3,7 @@ namespace Pidp.Infrastructure.Auth;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
-using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
 using System.Security.Claims;
 
 using Pidp.Extensions;
@@ -15,9 +15,9 @@ public static class AuthenticationSetup
         services.ThrowIfNull(nameof(services));
         config.ThrowIfNull(nameof(config));
 
-        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+        JsonWebTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        services.AddAuthentication()
         .AddJwtBearer(options =>
         {
             options.Authority = config.Keycloak.RealmUrl;

--- a/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
+++ b/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
@@ -25,7 +25,7 @@ public static class MassTransitSetup
                 cfg.UseDelayedRedelivery(r => r.Intervals(TimeSpan.FromHours(1), TimeSpan.FromHours(3), TimeSpan.FromHours(6), TimeSpan.FromHours(12)));
                 // Configure retry policy
                 cfg.UseMessageRetry(r => r.Interval(2, TimeSpan.FromSeconds(5)));
-                cfg.UseInMemoryOutbox();
+                cfg.UseInMemoryOutbox(context);
 
                 cfg.ReceiveEndpoint("party-email-updated-bc-provider-queue", ep =>
                 {

--- a/backend/webapi/README.md
+++ b/backend/webapi/README.md
@@ -5,7 +5,7 @@
 [Download](https://visualstudio.microsoft.com/) install and sign-in
 
 ### Entity Framework (open CLI )
-dotnet tool install --gloabal dotnet-ef -- version 6.0
+dotnet tool install --gloabal dotnet-ef
 
 #####  Docker Desktop
 [Download](https://www.docker.com/products/docker-desktop/) install and sign-in

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -66,7 +66,7 @@ public class Startup
         services.AddHealthChecks()
             .AddApplicationStatus(tags: new[] { HealthCheckTag.Liveness.Value })
             .AddCheck<BackgroundWorkerHealthCheck>("PlrStatusUpdateSchedulingService", tags: new[] { HealthCheckTag.BackgroundServices.Value })
-            .AddDbContextCheck<PidpDbContext>(tags: new[] { HealthCheckTag.Readiness.Value })
+            .AddNpgSql(config.ConnectionStrings.PidpDatabase, tags: new[] { HealthCheckTag.Readiness.Value })
             .AddRabbitMQ(new Uri(config.RabbitMQ.HostAddress), tags: new[] { HealthCheckTag.Readiness.Value });
 
         services.AddSwaggerGen(options =>

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -66,7 +66,7 @@ public class Startup
         services.AddHealthChecks()
             .AddApplicationStatus(tags: new[] { HealthCheckTag.Liveness.Value })
             .AddCheck<BackgroundWorkerHealthCheck>("PlrStatusUpdateSchedulingService", tags: new[] { HealthCheckTag.BackgroundServices.Value })
-            .AddNpgSql(config.ConnectionStrings.PidpDatabase, tags: new[] { HealthCheckTag.Readiness.Value })
+            .AddDbContextCheck<PidpDbContext>(tags: new[] { HealthCheckTag.Readiness.Value })
             .AddRabbitMQ(new Uri(config.RabbitMQ.HostAddress), tags: new[] { HealthCheckTag.Readiness.Value });
 
         services.AddSwaggerGen(options =>

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -66,7 +66,7 @@ public class Startup
         services.AddHealthChecks()
             .AddApplicationStatus(tags: new[] { HealthCheckTag.Liveness.Value })
             .AddCheck<BackgroundWorkerHealthCheck>("PlrStatusUpdateSchedulingService", tags: new[] { HealthCheckTag.BackgroundServices.Value })
-            .AddNpgSql(config.ConnectionStrings.PidpDatabase, tags: new[] { HealthCheckTag.Readiness.Value })
+            .AddNpgSql(tags: new[] { HealthCheckTag.Readiness.Value })
             .AddRabbitMQ(new Uri(config.RabbitMQ.HostAddress), tags: new[] { HealthCheckTag.Readiness.Value });
 
         services.AddSwaggerGen(options =>

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -66,7 +66,7 @@ public class Startup
         services.AddHealthChecks()
             .AddApplicationStatus(tags: new[] { HealthCheckTag.Liveness.Value })
             .AddCheck<BackgroundWorkerHealthCheck>("PlrStatusUpdateSchedulingService", tags: new[] { HealthCheckTag.BackgroundServices.Value })
-            .AddNpgSql(tags: new[] { HealthCheckTag.Readiness.Value })
+            .AddNpgSql(config.ConnectionStrings.PidpDatabase, tags: new[] { HealthCheckTag.Readiness.Value })
             .AddRabbitMQ(new Uri(config.RabbitMQ.HostAddress), tags: new[] { HealthCheckTag.Readiness.Value });
 
         services.AddSwaggerGen(options =>

--- a/backend/webapi/pidp.csproj
+++ b/backend/webapi/pidp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.ApplicationStatus" Version="8.0.1" />
-    <!-- <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" /> -->
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.RabbitMQ" Version="8.0.1" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="DomainResult" Version="3.2.0" />

--- a/backend/webapi/pidp.csproj
+++ b/backend/webapi/pidp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Pidp</RootNamespace>
@@ -22,18 +22,18 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.16" />
     <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Graph" Version="5.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Graph" Version="5.53.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.11.0" />
     <PackageReference Include="Nanoid" Version="3.0.0" />
     <PackageReference Include="NodaTime" Version="3.1.6" />

--- a/backend/webapi/pidp.csproj
+++ b/backend/webapi/pidp.csproj
@@ -7,21 +7,20 @@
     <UserSecretsId>5c2dc965-00b4-4531-9ff0-9b37193ead9b</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.ApplicationStatus" Version="6.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.RabbitMQ" Version="6.0.2" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="DomainResult" Version="2.0.0" />
-    <PackageReference Include="EntityFrameworkCore.Projectables" Version="2.3.0" />
-    <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
-    <PackageReference Include="Flurl" Version="3.0.7" />
+    <PackageReference Include="AspNetCore.HealthChecks.ApplicationStatus" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.RabbitMQ" Version="8.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="DomainResult" Version="3.2.0" />
+    <PackageReference Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
+    <PackageReference Include="FluentValidation" Version="11.9.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Flurl" Version="4.0.0" />
     <PackageReference Include="HybridModelBinding" Version="0.18.0" />
-    <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.16" />
-    <PackageReference Include="MediatR" Version="12.0.1" />
-    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
@@ -33,19 +32,19 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Graph" Version="5.53.0" />
-    <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.11.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.54.0" />
+    <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.18.2" />
     <PackageReference Include="Nanoid" Version="3.0.0" />
-    <PackageReference Include="NodaTime" Version="3.1.6" />
-    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="6.0.3" />
-    <PackageReference Include="Scrutor" Version="4.2.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="8.0.4" />
+    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
   </ItemGroup>
 </Project>

--- a/backend/webapi/pidp.csproj
+++ b/backend/webapi/pidp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.ApplicationStatus" Version="8.0.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
+    <!-- <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" /> -->
     <PackageReference Include="AspNetCore.HealthChecks.RabbitMQ" Version="8.0.1" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="DomainResult" Version="3.2.0" />

--- a/backend/webapi/pidp.csproj
+++ b/backend/webapi/pidp.csproj
@@ -21,17 +21,17 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Microsoft.Graph" Version="5.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.18.2" />
     <PackageReference Include="Nanoid" Version="3.0.0" />


### PR DESCRIPTION
The PLR intake microservice has not been updated as the SAML / mutual auth portion is hard to test ourselves. Once we can get a little bit of the PLR team's time to run the test distributions again we will upgrade.

Developers will need to update their SDK version to 8.0, as well as upgrade Entity Framework CLI:
`dotnet tool update dotnet-ef --global`