### PR TITLE
Fix scrolling inside Access Request Cards

### DIFF
--- a/workspace/apps/pidp/src/app/features/access/components/access-request-card/access-request-card.component.scss
+++ b/workspace/apps/pidp/src/app/features/access/components/access-request-card/access-request-card.component.scss
@@ -58,6 +58,10 @@
 }
 
 .container.viewport-xsmall {
+  .card-container {
+    height: 15rem;
+    overflow-y: auto;
+  }
   .card-header-icon fa-icon {
     padding: 5px;
     width: 8%;
@@ -78,6 +82,11 @@
 }
 
 .container.viewport-small {
+  .card-container {
+    height: 15rem;
+    overflow-y: auto;
+  }
+
   .card-header fa-icon {
     padding: 6px;
     width: 11%;
@@ -95,6 +104,10 @@
 }
 
 .container.viewport-medium {
+  .card-container {
+    height: 18rem;
+    overflow-y: auto;
+  }
   .card-header-text {
     padding-left: 5px;
     width: 88%;

--- a/workspace/apps/pidp/src/app/features/access/components/access-request-card/access-request-card.component.scss
+++ b/workspace/apps/pidp/src/app/features/access/components/access-request-card/access-request-card.component.scss
@@ -7,8 +7,7 @@
     margin: var(--margin-style);
     margin-left: 0;
     padding: var(--card-padding);
-    height: 15rem;
-    overflow-y: auto;
+    min-height: 15rem;
 
     & .card-header {
       & .card-header-icon {


### PR DESCRIPTION
-Access Request cards on desktop and laptop views will appear normally. Scrolling will only appear on smaller screens when the description text is long.