### PR TITLE
Refactor Portal page navigation

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/portal.page.html
+++ b/workspace/apps/pidp/src/app/features/portal/portal.page.html
@@ -16,7 +16,8 @@
         <div class="card-content">
           <p class="card-header">Linking Accounts</p>
           <p>Link different credentials together in OneHealthID</p>
-          <a (click)="navigateToAccountLinkingPage()">
+          <a
+            (click)="navigateTo(ProfileRoutes.routePath(ProfileRoutes.ACCOUNT_LINKING))">
             <fa-icon [icon]="faArrowRight"></fa-icon> READ MORE
           </a>
         </div>
@@ -30,7 +31,8 @@
         <div class="card-content">
           <p class="card-header">Acquire Access</p>
           <p>Acquire healthcare system access for myself</p>
-          <a (click)="navigateToAccessPage()">
+          <a
+            (click)="navigateTo(AccessRoutes.routePath(AccessRoutes.ACCESS_REQUESTS))">
             <fa-icon [icon]="faArrowRight"></fa-icon> READ MORE
           </a>
         </div>
@@ -44,7 +46,8 @@
         <div class="card-content">
           <p class="card-header">Grant Access</p>
           <p>Grant healthcare system access for others</p>
-          <a (click)="navigateToEndorsements()">
+          <a
+            (click)="navigateTo(OrganizationInfoRoutes.routePath(OrganizationInfoRoutes.ENDORSEMENTS))">
             <fa-icon [icon]="faArrowRight"></fa-icon> READ MORE
           </a>
         </div>

--- a/workspace/apps/pidp/src/app/features/portal/portal.page.ts
+++ b/workspace/apps/pidp/src/app/features/portal/portal.page.ts
@@ -36,6 +36,9 @@ export class PortalPage {
   public faArrowRight = faArrowRight;
   public faArrowUp = faArrowUp;
   public showBackToTopButton: boolean = false;
+  public ProfileRoutes = ProfileRoutes;
+  public AccessRoutes = AccessRoutes;
+  public OrganizationInfoRoutes = OrganizationInfoRoutes;
 
   public constructor(
     @Inject(APP_CONFIG) private config: AppConfig,
@@ -52,26 +55,12 @@ export class PortalPage {
     const scrollThreshold = 200;
     this.showBackToTopButton = scrollPosition > scrollThreshold;
   }
-  
+
   public scrollToTop(): void {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
-  
-  public navigateToAccountLinkingPage(): void {
-    this.router.navigateByUrl(
-      ProfileRoutes.routePath(ProfileRoutes.ACCOUNT_LINKING),
-    );
-  }
 
-  public navigateToAccessPage(): void {
-    this.router.navigateByUrl(
-      AccessRoutes.routePath(AccessRoutes.ACCESS_REQUESTS),
-    );
-  }
-
-  public navigateToEndorsements(): void {
-    this.router.navigateByUrl(
-      OrganizationInfoRoutes.routePath(OrganizationInfoRoutes.ENDORSEMENTS),
-    );
+  public navigateTo(path: string): void {
+    this.router.navigateByUrl(path);
   }
 }

--- a/workspace/apps/pidp/src/app/features/portal/portal.page.ts
+++ b/workspace/apps/pidp/src/app/features/portal/portal.page.ts
@@ -1,14 +1,12 @@
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { NgIf, NgOptimizedImage } from '@angular/common';
-import { Component, HostListener, Inject } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faArrowRight, faArrowUp } from '@fortawesome/free-solid-svg-icons';
 
 import { InjectViewportCssClassDirective } from '@bcgov/shared/ui';
-
-import { APP_CONFIG, AppConfig } from '@app/app.config';
 
 import { AccessRoutes } from '../access/access.routes';
 import { OrganizationInfoRoutes } from '../organization-info/organization-info.routes';
@@ -40,10 +38,7 @@ export class PortalPage {
   public AccessRoutes = AccessRoutes;
   public OrganizationInfoRoutes = OrganizationInfoRoutes;
 
-  public constructor(
-    @Inject(APP_CONFIG) private config: AppConfig,
-    private router: Router,
-  ) {}
+  public constructor(private router: Router) {}
 
   @HostListener('window:scroll', [])
   public onWindowScroll(): void {


### PR DESCRIPTION
- Merged the three methods into one with a `path` argument that calls the static `routePath(route)`  method for each route.
- Removed `config` as it is no longer used on `portal.page.ts`.