### PR TITLE
Fix BC Provider in Dev

### DIFF
--- a/backend/webapi/Features/Credentials/BCProvider.Create.cs
+++ b/backend/webapi/Features/Credentials/BCProvider.Create.cs
@@ -177,11 +177,6 @@ public class BCProviderCreate
         /// </summary>
         private string GenerateMohKeycloakUsername(string userPrincipalName)
         {
-            if (this.keycloakAdministrationUrl.Host == "user-management-dev.api.hlth.gov.bc.ca")
-            {
-                return userPrincipalName;
-            }
-
             return userPrincipalName + "@bcp";
         }
 


### PR DESCRIPTION
Before, the MOH Keycloak treated BC Provider accounts in Dev differently than in Test and Prod. In Dev, the Username was missing the `@IdentityProvider` suffix. 
Recently, the Dev MOH Keycloak was updated to be the same as Test and Prod.