### PR TITLE
Remove feature flag from PRP.

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
@@ -124,9 +124,7 @@ export class AccessStateBuilder {
         ],
       ),
       ...ArrayUtils.insertResultIf<IAccessSection>(
-        // TODO remove permissions when ready for production
-        this.insertSection('providerReportingPortal', profileStatus) &&
-          this.permissionsService.hasRole([Role.FEATURE_PIDP_DEMO]),
+        this.insertSection('providerReportingPortal', profileStatus),
         () => [new ProviderReportingPortalSection(profileStatus, this.router)],
       ),
       ...ArrayUtils.insertResultIf<IAccessSection>(


### PR DESCRIPTION
1. Remove feature flag from PRP.
2. The feature will be available for production.
3. Any user with the roles Physician and Pharmacist will be able to see the PRP card.