### PR TITLE
PIDP-1158 - Set isPharm attribute in BC Provider

### DIFF
--- a/backend/services.plr-intake/Features/Records/StatusLog.cs
+++ b/backend/services.plr-intake/Features/Records/StatusLog.cs
@@ -20,6 +20,7 @@ public class StatusLog
         public string? Cpn { get; set; }
         public string? NewStatusCode { get; set; }
         public string? NewStatusReasonCode { get; set; }
+        public string? IdentifierType { get; set; }
         public string? ProviderRoleType { get; set; }
 
         public bool IsGoodStanding => PlrRecord.ComputeGoodStanding(this.NewStatusCode, this.NewStatusReasonCode);
@@ -59,6 +60,7 @@ public class StatusLog
                     Cpn = log.PlrRecord!.Cpn,
                     NewStatusCode = log.NewStatusCode,
                     NewStatusReasonCode = log.NewStatusReasonCode,
+                    IdentifierType = log.PlrRecord.IdentifierType,
                     ProviderRoleType = log.PlrRecord.ProviderRoleType
                 })
                 .ToListAsync();

--- a/backend/webapi.tests/Features/CommonEventHandlers/UpdateKeycloakAfterCollegeLicenceUpdated.cs
+++ b/backend/webapi.tests/Features/CommonEventHandlers/UpdateKeycloakAfterCollegeLicenceUpdated.cs
@@ -44,17 +44,13 @@ public class UpdateKeycloakAfterCollegeLicenceUpdatedTests : InMemoryDbTest
 
         var message = capturedMessages.Single();
         Assert.Equal(party.PrimaryUserId, message.UserId);
-        Assert.Equal(2, message.Attributes.Count);
+        Assert.Single(message.Attributes);
 
-        var attribute1 = message.Attributes.Single(a => a.Key == "college_licence_info");
-        Assert.Equal("college_licence_info", attribute1.Key);
-        Assert.Single(attribute1.Value);
+        var attribute = message.Attributes.Single();
+        Assert.Equal("college_licence_info", attribute.Key);
+        Assert.Single(attribute.Value);
 
-        var attribute2 = message.Attributes.Single(a => a.Key == "is_pharm");
-        Assert.Equal("is_pharm", attribute2.Key);
-        Assert.Single(attribute2.Value);
-
-        var busRecords = JsonSerializer.Deserialize<IEnumerable<PlrRecord>>(attribute1.Value[0], new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
+        var busRecords = JsonSerializer.Deserialize<IEnumerable<PlrRecord>>(attribute.Value[0], new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
 
         AssertThat.CollectionsAreEquivalent(expectedRecords, busRecords, (expected, bus) =>
             expected.CollegeId == bus.CollegeId

--- a/backend/webapi/Features/CommonHandlers/CollegeLicenceUpdatedHandler.cs
+++ b/backend/webapi/Features/CommonHandlers/CollegeLicenceUpdatedHandler.cs
@@ -41,15 +41,9 @@ public class UpdateKeycloakAfterCollegeLicenceUpdated(
             return;
         }
 
-        var isPharmacist = PlrStandingsDigest.FromRecords(records)
-            .With(IdentifierType.Pharmacist)
-            .HasGoodStanding;
-
         foreach (var userId in party.Credentials.Select(credential => credential.UserId))
         {
-            await this.bus.Publish(UpdateKeycloakAttributes.FromUpdateAction(userId, user => user
-                .SetCollegeLicenceInformation(records)
-                .SetIsPharm(isPharmacist)), cancellationToken);
+            await this.bus.Publish(UpdateKeycloakAttributes.FromUpdateAction(userId, user => user.SetCollegeLicenceInformation(records)), cancellationToken);
         }
     }
 }

--- a/backend/webapi/Features/CommonHandlers/PlrCpnLookupFoundHandlers.cs
+++ b/backend/webapi/Features/CommonHandlers/PlrCpnLookupFoundHandlers.cs
@@ -77,6 +77,7 @@ public class UpdateBCProviderAfterPlrCpnLookupFound(
 
         var attributes = new BCProviderAttributes(this.clientId)
             .SetCpn(notification.Cpn)
+            .SetIsPharm(notification.StandingsDigest.With(IdentifierType.Pharmacist).HasGoodStanding)
             .SetIsRnp(notification.StandingsDigest.With(ProviderRoleType.RegisteredNursePractitioner).HasGoodStanding)
             .SetIsMd(notification.StandingsDigest.With(ProviderRoleType.MedicalDoctor).HasGoodStanding);
 

--- a/backend/webapi/Features/Credentials/BCProvider.Create.cs
+++ b/backend/webapi/Features/Credentials/BCProvider.Create.cs
@@ -102,6 +102,7 @@ public class BCProviderCreate
                 Hpdid = party.Hpdid,
                 IsRnp = plrStanding.With(ProviderRoleType.RegisteredNursePractitioner).HasGoodStanding,
                 IsMd = plrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding,
+                IsPharm = plrStanding.With(IdentifierType.Pharmacist).HasGoodStanding,
                 Cpn = party.Cpn,
                 Password = command.Password,
                 PidpEmail = party.Email,

--- a/backend/webapi/Features/Credentials/Create.cs
+++ b/backend/webapi/Features/Credentials/Create.cs
@@ -157,6 +157,7 @@ public class Create
                 .SetPidpEmail(party.Email!)
                 .SetIsRnp(plrStanding.With(ProviderRoleType.RegisteredNursePractitioner).HasGoodStanding)
                 .SetIsMd(plrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding)
+                .SetIsPharm(plrStanding.With(IdentifierType.Pharmacist).HasGoodStanding)
                 .SetIsMoa(!plrStanding.HasGoodStanding && endorsementPlrDigest.HasGoodStanding)
                 .SetEndorserData(endorsementPlrDigest
                     .WithGoodStanding()

--- a/backend/webapi/Infrastructure/HttpClients/BCProvider/BCProviderApiDefinitions.cs
+++ b/backend/webapi/Infrastructure/HttpClients/BCProvider/BCProviderApiDefinitions.cs
@@ -11,6 +11,7 @@ public class NewUserRepresentation
     public string Hpdid { get; set; } = string.Empty;
     public bool IsMd { get; set; }
     public bool IsMoa { get; set; }
+    public bool IsPharm { get; set; }
     public bool IsRnp { get; set; }
     public string PidpEmail { get; set; } = string.Empty;
     public DateTimeOffset UaaDate { get; set; }
@@ -40,6 +41,7 @@ public class BCProviderAttributes(string clientId)
             .SetHpdid(representation.Hpdid)
             .SetIsMd(representation.IsMd)
             .SetIsMoa(representation.IsMoa)
+            .SetIsPharm(representation.IsPharm)
             .SetIsRnp(representation.IsRnp)
             .SetLoa(3)
             .SetPidpEmail(representation.PidpEmail)
@@ -63,6 +65,7 @@ public class BCProviderAttributes(string clientId)
     public BCProviderAttributes SetHpdid(string hpdid) => this.SetProperty(nameof(hpdid), hpdid);
     public BCProviderAttributes SetIsMd(bool isMd) => this.SetProperty(nameof(isMd), isMd);
     public BCProviderAttributes SetIsMoa(bool isMoa) => this.SetProperty(nameof(isMoa), isMoa);
+    public BCProviderAttributes SetIsPharm(bool isPharm) => this.SetProperty(nameof(isPharm), isPharm);
     public BCProviderAttributes SetIsRnp(bool isRnp) => this.SetProperty(nameof(isRnp), isRnp);
     /// <summary>
     /// Level Of Assurance. Is 3 for a BC Provider created from a BC Services Card.

--- a/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakApiDefinitions.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakApiDefinitions.cs
@@ -99,8 +99,6 @@ public class UserRepresentation
 
     public UserRepresentation SetCpn(string cpn) => this.SetAttribute("common_provider_number", cpn);
 
-    public UserRepresentation SetIsPharm(bool isPharm) => this.SetAttribute("is_pharm", isPharm.ToString());
-
     internal UserRepresentation SetLdapOrgDetails(LdapLoginResponse.OrgDetails orgDetails) => this.SetAttribute("org_details", JsonSerializer.Serialize(orgDetails, SerializationOptions));
 
     public UserRepresentation SetOpId(string opId) => this.SetAttribute("opId", opId);

--- a/backend/webapi/Infrastructure/HttpClients/Plr/PlrClientDefinitions.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Plr/PlrClientDefinitions.cs
@@ -237,5 +237,6 @@ public class PlrStatusChangeLog
     public int Id { get; set; }
     public string Cpn { get; set; } = string.Empty;
     public bool IsGoodStanding { get; set; }
+    public string? IdentifierType { get; set; }
     public string? ProviderRoleType { get; set; }
 }

--- a/backend/webapi/Infrastructure/Services/PlrStatusUpdateService.cs
+++ b/backend/webapi/Infrastructure/Services/PlrStatusUpdateService.cs
@@ -92,6 +92,10 @@ public sealed class PlrStatusUpdateService(
             {
                 bcProviderAttributes.SetIsRnp(status.IsGoodStanding);
             }
+            if (status.IdentifierType == IdentifierType.Pharmacist)
+            {
+                bcProviderAttributes.SetIsPharm(status.IsGoodStanding);
+            }
 
             await this.bcProviderClient.UpdateAttributes(upn, bcProviderAttributes.AsAdditionalData());
         }


### PR DESCRIPTION
The `isPharm` attribute was being set in keycloak due to an architectural misunderstanding. We now set it on the BC Provider account in AAD just like `isMD` and `isRNP`.