### PR TITLE
OHID-140-Refactor account linking requests for undefined PartyID

### DIFF
--- a/workspace/apps/pidp/src/app/features/portal/portal-resource.service.ts
+++ b/workspace/apps/pidp/src/app/features/portal/portal-resource.service.ts
@@ -14,6 +14,9 @@ export class PortalResource {
   public constructor(private apiResource: ApiHttpClient) {}
 
   public getProfileStatus(partyId: number): Observable<ProfileStatus | null> {
+    if (!partyId) {
+      return of(null);
+    }
     return this.apiResource
       .get<ProfileStatus>(`parties/${partyId}/profile-status`)
       .pipe(

--- a/workspace/apps/pidp/src/app/features/shell/components/navbar-menu/nav-menu.resource.service.ts
+++ b/workspace/apps/pidp/src/app/features/shell/components/navbar-menu/nav-menu.resource.service.ts
@@ -1,18 +1,22 @@
-import { HttpErrorResponse } from "@angular/common/http";
-import { Injectable } from "@angular/core";
-import { ApiHttpClient } from "@app/core/resources/api-http-client.service";
-import { catchError, Observable, throwError } from "rxjs";
-import { Credential } from "./nav-menu.model";
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { Observable, catchError, of, throwError } from 'rxjs';
+
+import { ApiHttpClient } from '@app/core/resources/api-http-client.service';
+
+import { Credential } from './nav-menu.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class NavMenuResource {
-  public constructor(
-    protected apiResource: ApiHttpClient
-  ) {}
+  public constructor(protected apiResource: ApiHttpClient) {}
 
-  public getCredentials(partyId: number): Observable<Credential[]> {
+  public getCredentials(partyId: number): Observable<Credential[] | null> {
+    if (!partyId) {
+      return of(null);
+    }
     return this.apiResource
       .get<Credential[]>(this.getResourcePath(partyId))
       .pipe(

--- a/workspace/apps/pidp/src/app/features/shell/components/navbar-menu/nav-menu.ts
+++ b/workspace/apps/pidp/src/app/features/shell/components/navbar-menu/nav-menu.ts
@@ -47,9 +47,9 @@ import { IdentityProvider } from '@app/features/auth/enums/identity-provider.enu
 import { AlertCode } from '@app/features/portal/enums/alert-code.enum';
 import { ProfileRoutes } from '@app/features/profile/profile.routes';
 
+import { FeedbackButtonComponent } from '../../../../shared/components/feedback-button/feedback-button.component';
 import { Credential } from './nav-menu.model';
 import { NavMenuResource } from './nav-menu.resource.service';
-import { FeedbackButtonComponent } from "../../../../shared/components/feedback-button/feedback-button.component";
 
 @Component({
   selector: 'app-nav-menu',
@@ -71,8 +71,8 @@ import { FeedbackButtonComponent } from "../../../../shared/components/feedback-
     RouterOutlet,
     FaIconComponent,
     NgClass,
-    FeedbackButtonComponent
-],
+    FeedbackButtonComponent,
+  ],
 })
 export class NavMenuComponent implements OnChanges, OnInit, OnDestroy {
   @Input() public alerts: AlertCode[] | null = [];
@@ -95,8 +95,8 @@ export class NavMenuComponent implements OnChanges, OnInit, OnDestroy {
   public showCollegeAlert = false;
   public faBell = faBell;
   public AlertCode = AlertCode;
-  public credentials: Credential[] = [];
-  public credentials$: Observable<Credential[]>;
+  public credentials: Credential[] | null = [];
+  public credentials$: Observable<Credential[] | null>;
   private unsubscribe$ = new Subject<void>();
   public IdentityProvider = IdentityProvider;
 
@@ -170,8 +170,8 @@ export class NavMenuComponent implements OnChanges, OnInit, OnDestroy {
     return undefined;
   }
 
-  public hasCredential(idp: IdentityProvider): boolean {
-    return this.credentials.some((c) => c.identityProvider === idp);
+  public hasCredential(idp: IdentityProvider): boolean | undefined {
+    return this.credentials?.some((c) => c.identityProvider === idp);
   }
 
   public onLogout(): void {


### PR DESCRIPTION
No impact to the user. During uplifting of a BCProvider, potentially during every account linking process, there are 2 GET requests that are made to parties/undefined. Refactor so that these requests are not made since there is no PartyId at the time.