### PR TITLE
Pidp 1054 wrap bcprovider creation in rabbitmq with masstransit saga

### DIFF
--- a/backend/webapi/Features/Credentials/BCProvider.Create.cs
+++ b/backend/webapi/Features/Credentials/BCProvider.Create.cs
@@ -14,7 +14,7 @@ using Pidp.Infrastructure.HttpClients.BCProvider;
 using Pidp.Infrastructure.HttpClients.Keycloak;
 using Pidp.Infrastructure.HttpClients.Plr;
 using Pidp.Models.Lookups;
-using Pidp.Infrastructure.Queue.Events;
+using Pidp.Infrastructure.Queue;
 
 public class BCProviderCreate
 {

--- a/backend/webapi/Infrastructure/Queue/Activities/SendEmailActivity.cs
+++ b/backend/webapi/Infrastructure/Queue/Activities/SendEmailActivity.cs
@@ -1,0 +1,33 @@
+namespace Pidp.Infrastructure.Queue.Activities;
+
+using MassTransit;
+using Pidp.Infrastructure.HttpClients.Mail;
+using Pidp.Infrastructure.Queue.Events;
+using Pidp.Infrastructure.Services;
+using System.Threading.Tasks;
+
+public class SendEmailActivity(IEmailService emailService) : IStateMachineActivity<BCProviderSagaState, KeycloakUserUpdatedEvent>
+{
+    private readonly IEmailService emailService = emailService;
+
+    public void Probe(ProbeContext context) => context.CreateScope("send-email");
+
+    public void Accept(StateMachineVisitor visitor) => visitor.Visit(this);
+
+    public async Task Execute(BehaviorContext<BCProviderSagaState, KeycloakUserUpdatedEvent> context, IBehavior<BCProviderSagaState, KeycloakUserUpdatedEvent> next)
+    {
+        var message = context.Message;
+        var email = new Email(
+            from: EmailService.PidpEmail,
+            to: message.Email,
+            subject: "BCProvider Account Creation in OneHealthID Confirmation",
+            body: $"You have successfully created a BCProvider account in OneHealthID Service. For your reference, your BCProvider username is {message.UserPrincipalName}. You may now login to OneHealthID Service and access the BCProvider card to update your BCProvider password."
+        );
+
+        await this.emailService.SendAsync(email);
+
+        await next.Execute(context).ConfigureAwait(false);
+    }
+
+    public Task Faulted<TException>(BehaviorExceptionContext<BCProviderSagaState, KeycloakUserUpdatedEvent, TException> context, IBehavior<BCProviderSagaState, KeycloakUserUpdatedEvent> next) where TException : Exception => next.Faulted(context);
+}

--- a/backend/webapi/Infrastructure/Queue/BCProviderSaga.cs
+++ b/backend/webapi/Infrastructure/Queue/BCProviderSaga.cs
@@ -1,17 +1,18 @@
-namespace Pidp.Infrastructure.Services;
+namespace Pidp.Infrastructure.Queue;
 
 using MassTransit;
-using Pidp.Infrastructure.Queue.Events;
 using Pidp.Infrastructure.HttpClients.Keycloak;
-using Pidp.Infrastructure.Queue;
-using Pidp.Infrastructure.Queue.Activities;
 
-
-public class BCProviderSagaService : MassTransitStateMachine<BCProviderSagaState>
+public class BCProviderSaga : MassTransitStateMachine<BCProviderSagaState>
 {
+    public required State AssigningAccessRoles { get; set; }
+    public required State SendingEmail { get; set; }
+    public required State Completed { get; set; }
+    public required Event<KeycloakUserUpdatedEvent> KeycloakUserUpdated { get; set; }
+
     private readonly IKeycloakAdministrationClient keycloakClient;
 
-    public BCProviderSagaService(IKeycloakAdministrationClient keycloakClient)
+    public BCProviderSaga(IKeycloakAdministrationClient keycloakClient)
     {
         this.keycloakClient = keycloakClient;
 
@@ -39,11 +40,5 @@ public class BCProviderSagaService : MassTransitStateMachine<BCProviderSagaState
                 .Activity(x => x.OfType<SendEmailActivity>())
                 .TransitionTo(this.Completed));
     }
-
-    public required State AssigningAccessRoles { get; set; }
-    public required State SendingEmail { get; set; }
-    public required State Completed { get; set; }
-
-    public required Event<KeycloakUserUpdatedEvent> KeycloakUserUpdated { get; set; }
 }
 

--- a/backend/webapi/Infrastructure/Queue/BCProviderSagaState.cs
+++ b/backend/webapi/Infrastructure/Queue/BCProviderSagaState.cs
@@ -1,0 +1,15 @@
+namespace Pidp.Infrastructure.Queue;
+
+using MassTransit;
+using System;
+
+public class BCProviderSagaState : SagaStateMachineInstance
+{
+    public Guid CorrelationId { get; set; }
+    public required string CurrentState { get; set; }
+    public Guid PartyId { get; set; }
+    public required string UserPrincipalName { get; set; }
+    public Guid UserId { get; set; }
+    public bool SAEformsEnroled { get; set; }
+    public required string Email { get; set; }
+}

--- a/backend/webapi/Infrastructure/Queue/Events.cs
+++ b/backend/webapi/Infrastructure/Queue/Events.cs
@@ -1,0 +1,11 @@
+namespace Pidp.Infrastructure.Queue.Events;
+
+public class KeycloakUserUpdatedEvent
+{
+    public required string OpId { get; set; }
+    public Guid PartyId { get; set; }
+    public Guid UserId { get; set; }
+    public bool SAEformsEnroled { get; set; }
+    public required string Email { get; set; }
+    public required string UserPrincipalName { get; set; }
+}

--- a/backend/webapi/Infrastructure/Queue/Events.cs
+++ b/backend/webapi/Infrastructure/Queue/Events.cs
@@ -1,4 +1,4 @@
-namespace Pidp.Infrastructure.Queue.Events;
+namespace Pidp.Infrastructure.Queue;
 
 public class KeycloakUserUpdatedEvent
 {

--- a/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
+++ b/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
@@ -3,7 +3,6 @@ namespace Pidp.Infrastructure.Queue;
 using MassTransit;
 using Pidp;
 using Pidp.Features.CommonHandlers;
-using Pidp.Infrastructure.Services;
 using static Pidp.Features.Parties.Demographics;
 
 public static class MassTransitSetup
@@ -17,7 +16,7 @@ public static class MassTransitSetup
             x.AddConsumer<PartyEmailUpdatedBcProviderConsumer>();
             x.AddConsumer<UpdateBcProviderAttributesConsumer>();
             x.AddConsumer<UpdateKeycloakAttributesConsumer>();
-            x.AddSagaStateMachine<BCProviderSagaService, BCProviderSagaState>()
+            x.AddSagaStateMachine<BCProviderSaga, BCProviderSagaState>()
                 .InMemoryRepository();
 
             x.UsingRabbitMq((context, cfg) =>

--- a/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
+++ b/backend/webapi/Infrastructure/Queue/MassTransitSetup.cs
@@ -3,6 +3,7 @@ namespace Pidp.Infrastructure.Queue;
 using MassTransit;
 using Pidp;
 using Pidp.Features.CommonHandlers;
+using Pidp.Infrastructure.Services;
 using static Pidp.Features.Parties.Demographics;
 
 public static class MassTransitSetup
@@ -16,6 +17,8 @@ public static class MassTransitSetup
             x.AddConsumer<PartyEmailUpdatedBcProviderConsumer>();
             x.AddConsumer<UpdateBcProviderAttributesConsumer>();
             x.AddConsumer<UpdateKeycloakAttributesConsumer>();
+            x.AddSagaStateMachine<BCProviderSagaService, BCProviderSagaState>()
+                .InMemoryRepository();
 
             x.UsingRabbitMq((context, cfg) =>
             {
@@ -47,6 +50,8 @@ public static class MassTransitSetup
                     ep.Bind("update-keycloak-attributes");
                     ep.ConfigureConsumer<UpdateKeycloakAttributesConsumer>(context);
                 });
+
+                cfg.ReceiveEndpoint("bc-provider-saga", ep => ep.ConfigureSaga<BCProviderSagaState>(context));
             });
         });
 

--- a/backend/webapi/Infrastructure/Services/BCProviderSagaService.cs
+++ b/backend/webapi/Infrastructure/Services/BCProviderSagaService.cs
@@ -1,0 +1,49 @@
+namespace Pidp.Infrastructure.Services;
+
+using MassTransit;
+using Pidp.Infrastructure.Queue.Events;
+using Pidp.Infrastructure.HttpClients.Keycloak;
+using Pidp.Infrastructure.Queue;
+using Pidp.Infrastructure.Queue.Activities;
+
+
+public class BCProviderSagaService : MassTransitStateMachine<BCProviderSagaState>
+{
+    private readonly IKeycloakAdministrationClient keycloakClient;
+
+    public BCProviderSagaService(IKeycloakAdministrationClient keycloakClient)
+    {
+        this.keycloakClient = keycloakClient;
+
+        this.InstanceState(x => x.CurrentState);
+
+        this.Event(() => this.KeycloakUserUpdated, x => x.CorrelateById(context => context.Message.PartyId));
+
+        this.Initially(
+            this.When(this.KeycloakUserUpdated)
+                .Then(async context =>
+                {
+                    var message = context.Message;
+                    await this.keycloakClient.UpdateUser(message.UserId, user => user.SetOpId(message.OpId));
+                })
+                .TransitionTo(this.AssigningAccessRoles)
+                .Then(async context =>
+                {
+                    var message = context.Message;
+                    if (message.SAEformsEnroled)
+                    {
+                        await this.keycloakClient.AssignAccessRoles(message.UserId, MohKeycloakEnrolment.SAEforms);
+                    }
+                })
+                .TransitionTo(this.SendingEmail)
+                .Activity(x => x.OfType<SendEmailActivity>())
+                .TransitionTo(this.Completed));
+    }
+
+    public required State AssigningAccessRoles { get; set; }
+    public required State SendingEmail { get; set; }
+    public required State Completed { get; set; }
+
+    public required Event<KeycloakUserUpdatedEvent> KeycloakUserUpdated { get; set; }
+}
+

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -24,6 +24,7 @@ using Pidp.Infrastructure.HealthChecks;
 using Pidp.Infrastructure.HttpClients;
 using Pidp.Infrastructure.Services;
 using Pidp.Infrastructure.Queue;
+using Pidp.Infrastructure.Queue.Activities;
 
 public class Startup(IConfiguration configuration)
 {
@@ -44,6 +45,7 @@ public class Startup(IConfiguration configuration)
             .AddScoped<IEmailService, EmailService>()
             .AddScoped<IPidpAuthorizationService, PidpAuthorizationService>()
             .AddScoped<IPlrStatusUpdateService, PlrStatusUpdateService>()
+            .AddScoped<SendEmailActivity>()
             .AddSingleton<IClock>(SystemClock.Instance)
             .AddSingleton<BackgroundWorkerHealthCheck>();
 

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -24,7 +24,6 @@ using Pidp.Infrastructure.HealthChecks;
 using Pidp.Infrastructure.HttpClients;
 using Pidp.Infrastructure.Services;
 using Pidp.Infrastructure.Queue;
-using Pidp.Infrastructure.Queue.Activities;
 
 public class Startup(IConfiguration configuration)
 {


### PR DESCRIPTION
1. Masstransit Saga added for performing series of activities.
2. After BCProviderCreation successful KeycloakUserUpdate event is published which triggers initial state of saga.
3. 3 different states added in saga. 1. KeycloakUserUpdate 2. KeycloakUserAssignAccessRoles 3. SendEmail
4. SendEmail is wrapped in the custom activity as  it uses the scoped services for adding credentials into db and sending the email.
