### PR TITLE
feature/Rsv role removal + logic improvements

### DIFF
--- a/backend/services.plr-intake/Features/Intake/IntakeService.cs
+++ b/backend/services.plr-intake/Features/Intake/IntakeService.cs
@@ -132,7 +132,8 @@ public class IntakeService : IIntakeService
                 OldStatusReasonCode = existingRecord?.StatusReasonCode,
                 NewStatusCode = newRecord.StatusCode,
                 NewStatusReasonCode = newRecord.StatusReasonCode,
-                ShouldBeProcessed = existingRecord?.IsGoodStanding != newRecord.IsGoodStanding
+                // Every status change is processable
+                ShouldBeProcessed = true
             });
         }
     }

--- a/backend/services.plr-intake/Features/Records/StatusLog.cs
+++ b/backend/services.plr-intake/Features/Records/StatusLog.cs
@@ -18,6 +18,8 @@ public class StatusLog
     {
         public int Id { get; set; }
         public string? Cpn { get; set; }
+        public string? OldStatusCode { get; set; }
+        public string? OldStatusReasonCode { get; set; }
         public string? NewStatusCode { get; set; }
         public string? NewStatusReasonCode { get; set; }
         public string? IdentifierType { get; set; }
@@ -58,6 +60,8 @@ public class StatusLog
                 {
                     Id = log.Id,
                     Cpn = log.PlrRecord!.Cpn,
+                    OldStatusCode = log.OldStatusCode,
+                    OldStatusReasonCode = log.OldStatusReasonCode,
                     NewStatusCode = log.NewStatusCode,
                     NewStatusReasonCode = log.NewStatusReasonCode,
                     IdentifierType = log.PlrRecord.IdentifierType,

--- a/backend/webapi/Data/Migrations/20260807000000_InfantRsvEforms.Designer.cs
+++ b/backend/webapi/Data/Migrations/20260807000000_InfantRsvEforms.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Pidp.Data;
 namespace Pidp.Data.Migrations
 {
     [DbContext(typeof(PidpDbContext))]
-    partial class PidpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807000000_InfantRsvEforms")]
+    partial class InfantRsvEforms
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/webapi/Data/Migrations/20260807000000_InfantRsvEforms.cs
+++ b/backend/webapi/Data/Migrations/20260807000000_InfantRsvEforms.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pidp.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class InfantRsvEforms : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "AccessTypeLookup",
+                columns: new[] { "Code", "Name" },
+                values: new object[] { 12, "Infant RSV Immunization Request eForm" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AccessTypeLookup",
+                keyColumn: "Code",
+                keyValue: 12);
+        }
+    }
+}

--- a/backend/webapi/Data/Migrations/20260814225415_AccessRequestRevoked.Designer.cs
+++ b/backend/webapi/Data/Migrations/20260814225415_AccessRequestRevoked.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Pidp.Data;
 namespace Pidp.Data.Migrations
 {
     [DbContext(typeof(PidpDbContext))]
-    partial class PidpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814225415_AccessRequestRevoked")]
+    partial class AccessRequestRevoked
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/webapi/Data/Migrations/20260814225415_AccessRequestRevoked.cs
+++ b/backend/webapi/Data/Migrations/20260814225415_AccessRequestRevoked.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Pidp.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AccessRequestRevoked : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/backend/webapi/Features/AccessRequests/AccessRequestsController.cs
+++ b/backend/webapi/Features/AccessRequests/AccessRequestsController.cs
@@ -91,6 +91,15 @@ public class AccessRequestsController(IPidpAuthorizationService authorizationSer
         => await this.AuthorizePartyBeforeHandleAsync(command.PartyId, handler, command)
             .ToActionResult();
 
+    [HttpPost("infant-rsv-eforms")]
+    [Authorize(Policy = Policies.HighAssuranceIdentityProvider)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateInfantRsvEformsEnrolment([FromServices] ICommandHandler<InfantRsvEforms.Command, IDomainResult> handler,
+                                                                    [FromRoute] InfantRsvEforms.Command command)
+        => await this.AuthorizePartyBeforeHandleAsync(command.PartyId, handler, command)
+            .ToActionResult();
+
     [HttpPost("ms-teams-clinic-member")]
     [Authorize(Policy = Policies.HighAssuranceIdentityProvider)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/backend/webapi/Features/AccessRequests/InfantRsvEforms.Revoke.cs
+++ b/backend/webapi/Features/AccessRequests/InfantRsvEforms.Revoke.cs
@@ -1,0 +1,168 @@
+namespace Pidp.Features.AccessRequests;
+
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+using Pidp.Data;
+using Pidp.Extensions;
+using Pidp.Infrastructure.HttpClients.Keycloak;
+using Pidp.Infrastructure.HttpClients.Plr;
+using Pidp.Models;
+using Pidp.Models.Lookups;
+
+public interface IInfantRsvEformsRevocationService
+{
+    /// <summary>
+    /// Re-evaluates the Party's eligibility for the Infant RSV eForms enrolment and, if they are no
+    /// longer eligible, removes the Keycloak role and deletes the Access Request.
+    /// Changes are staged on the shared DbContext; the caller owns SaveChangesAsync.
+    /// Does nothing if the Party does not hold the enrolment.
+    /// </summary>
+    Task RevokeIfIneligibleAsync(int partyId, PlrStatusChangeLog? statusChange = null, CancellationToken cancellationToken = default);
+}
+
+public class InfantRsvEformsRevocationService(
+    IClock clock,
+    IKeycloakAdministrationClient keycloakClient,
+    ILogger<InfantRsvEformsRevocationService> logger,
+    IPlrClient plrClient,
+    PidpDbContext context) : IInfantRsvEformsRevocationService
+{
+    private readonly IClock clock = clock;
+    private readonly IKeycloakAdministrationClient keycloakClient = keycloakClient;
+    private readonly ILogger<InfantRsvEformsRevocationService> logger = logger;
+    private readonly IPlrClient plrClient = plrClient;
+    private readonly PidpDbContext context = context;
+
+    public async Task RevokeIfIneligibleAsync(int partyId, PlrStatusChangeLog? statusChange = null, CancellationToken cancellationToken = default)
+    {
+        var dto = await this.context.Parties
+            .Where(party => party.Id == partyId)
+            .Select(party => new
+            {
+                AccessRequestId = party.AccessRequests
+                    .Where(request => request.AccessTypeCode == AccessTypeCode.InfantRsvEforms)
+                    .Select(request => (int?)request.Id)
+                    .FirstOrDefault(),
+                // Assign narrowly, remove broadly. The grant only ever targets BC Services Card
+                // credentials, but removing from all of them costs nothing (Keycloak returns 204
+                // for a role the User does not hold) and cleans up any grant made by an earlier
+                // version of the rule.
+                UserIds = party.Credentials
+                    .Select(credential => credential.UserId)
+                    .ToList(),
+                party.Cpn,
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (dto?.AccessRequestId == null)
+        {
+            return;
+        }
+
+        var (eligible, standingIsKnown, reason) = await this.EvaluateEligibilityAsync(partyId, dto.Cpn);
+
+        // Fail closed: an unreachable PLR yields a digest with no records, which looks exactly like
+        // "not in good standing". Revoking on that would strip every holder during an outage.
+        if (!standingIsKnown)
+        {
+            this.logger.LogRevocationSkippedPlrError(partyId);
+            return;
+        }
+
+        if (eligible)
+        {
+            return;
+        }
+
+        foreach (var userId in dto.UserIds)
+        {
+            if (!await this.keycloakClient.RemoveAccessRoles(userId, MohKeycloakEnrolment.InfantRsvEforms))
+            {
+                // Leave the Access Request in place so the next status change or endorsement
+                // update retries; deleting it would strand a live role with no record of it.
+                this.logger.LogRoleRemovalFailed(partyId, userId);
+                this.context.BusinessEvents.Add(AccessRequestRevoked.CreateFailure(
+                    partyId,
+                    AccessTypeCode.InfantRsvEforms,
+                    MohKeycloakEnrolment.InfantRsvEforms,
+                    dto.Cpn,
+                    dto.UserIds,
+                    reason,
+                    FormatTrigger(statusChange),
+                    this.clock.GetCurrentInstant()));
+                return;
+            }
+        }
+
+        // FindAsync returns the already-tracked instance when there is one, so this cannot collide
+        // with an AccessRequest the caller has loaded.
+        var accessRequest = await this.context.AccessRequests.FindAsync([dto.AccessRequestId.Value], cancellationToken);
+        if (accessRequest != null)
+        {
+            this.context.AccessRequests.Remove(accessRequest);
+        }
+
+        this.context.BusinessEvents.Add(AccessRequestRevoked.Create(
+            partyId,
+            AccessTypeCode.InfantRsvEforms,
+            MohKeycloakEnrolment.InfantRsvEforms,
+            dto.Cpn,
+            dto.UserIds,
+            reason,
+            FormatTrigger(statusChange),
+            this.clock.GetCurrentInstant()));
+
+        this.logger.LogAccessRevoked(partyId);
+    }
+
+    /// <summary>
+    /// Describes what prompted the re-evaluation, for the audit record. The PLR status change is
+    /// absent when an endorsement update triggered this rather than a licence status change.
+    /// </summary>
+    private static string? FormatTrigger(PlrStatusChangeLog? statusChange) => statusChange == null
+        ? "endorsement standing updated"
+        : $"PLR status {FormatStatus(statusChange.OldStatusCode, statusChange.OldStatusReasonCode)} -> {FormatStatus(statusChange.NewStatusCode, statusChange.NewStatusReasonCode)}";
+
+    private static string FormatStatus(string? statusCode, string? statusReasonCode) => statusCode == null && statusReasonCode == null
+        ? "unknown"
+        : $"{statusCode}/{statusReasonCode}";
+
+    /// <summary>
+    /// Mirrors the grant-time checks in InfantRsvEforms.CommandHandler: a Party with a CPN is judged
+    /// on their own standing, one without a CPN (i.e. an MOA) on their endorsements.
+    /// </summary>
+    private async Task<(bool Eligible, bool StandingIsKnown, string Reason)> EvaluateEligibilityAsync(int partyId, string? cpn)
+    {
+        if (cpn == null)
+        {
+            var endorsementCpns = await this.context.ActiveEndorsementRelationships(partyId)
+                .Select(relationship => relationship.Party!.Cpn)
+                .ToListAsync();
+
+            var endorsementPlrStanding = await this.plrClient.GetAggregateStandingsDigestAsync(endorsementCpns);
+
+            return (InfantRsvEforms.IsEligibleByEndorsement(endorsementPlrStanding),
+                !endorsementPlrStanding.Error,
+                "no active endorsement from a Medical Doctor, Nurse, or Midwife in good standing");
+        }
+
+        var partyPlrStanding = await this.plrClient.GetStandingsDigestAsync(cpn);
+
+        return (InfantRsvEforms.IsEligible(partyPlrStanding),
+            !partyPlrStanding.Error,
+            "licence no longer in good standing and not a CPS postgraduate");
+    }
+}
+
+public static partial class InfantRsvEformsRevocationLoggingExtensions
+{
+    [LoggerMessage(1, LogLevel.Information, "Infant RSV eForms access for Party {partyId} was revoked; they no longer meet the eligibility criteria.")]
+    public static partial void LogAccessRevoked(this ILogger<InfantRsvEformsRevocationService> logger, int partyId);
+
+    [LoggerMessage(2, LogLevel.Warning, "Could not determine PLR standing for Party {partyId}; Infant RSV eForms access was left in place.")]
+    public static partial void LogRevocationSkippedPlrError(this ILogger<InfantRsvEformsRevocationService> logger, int partyId);
+
+    [LoggerMessage(3, LogLevel.Error, "Failed to remove the Infant RSV eForms role from User {userId} of Party {partyId}; the Access Request was left in place to be retried.")]
+    public static partial void LogRoleRemovalFailed(this ILogger<InfantRsvEformsRevocationService> logger, int partyId, Guid userId);
+}

--- a/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
+++ b/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
@@ -24,6 +24,13 @@ public class InfantRsvEforms
             .HasGoodStanding || partyPlrStanding.IsCpsPostgrad;
     }
 
+    public static bool IsEligibleByEndorsement(PlrStandingsDigest endorsementPlrStanding)
+    {
+        return endorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding
+            || endorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding
+            || endorsementPlrStanding.With(IdentifierType.Midwife).HasGoodStanding;
+    }
+
     public class Command : ICommand<IDomainResult>
     {
         public int PartyId { get; set; }
@@ -81,9 +88,7 @@ public class InfantRsvEforms
 
                 var endorsementPlrStanding = await this.plrClient.GetAggregateStandingsDigestAsync(endorsementCpns);
 
-                if (!endorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding &&
-                    !endorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding &&
-                    !endorsementPlrStanding.With(IdentifierType.Midwife).HasGoodStanding)
+                if (!IsEligibleByEndorsement(endorsementPlrStanding))
                 {
                     this.logger.LogAccessRequestDenied(command.PartyId);
                     return DomainResult.Failed();

--- a/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
+++ b/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
@@ -1,0 +1,123 @@
+namespace Pidp.Features.AccessRequests;
+
+using DomainResults.Common;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+using Pidp.Data;
+using Pidp.Extensions;
+using Pidp.Infrastructure.Auth;
+using Pidp.Infrastructure.HttpClients.Keycloak;
+using Pidp.Infrastructure.HttpClients.Plr;
+using Pidp.Models;
+using Pidp.Models.Lookups;
+
+public class InfantRsvEforms
+{
+    public static IdentifierType[] AllowedIdentifierTypes => [IdentifierType.PhysiciansAndSurgeons, IdentifierType.Nurse];
+
+    public static bool IsEligible(PlrStandingsDigest partyPlrStanding)
+    {
+        return partyPlrStanding
+            .With(AllowedIdentifierTypes)
+            .HasGoodStanding || partyPlrStanding.IsCpsPostgrad;
+    }
+
+    public class Command : ICommand<IDomainResult>
+    {
+        public int PartyId { get; set; }
+    }
+
+    public class CommandValidator : AbstractValidator<Command>
+    {
+        public CommandValidator() => this.RuleFor(x => x.PartyId).GreaterThan(0);
+    }
+
+    public class CommandHandler(
+        IClock clock,
+        IKeycloakAdministrationClient keycloakClient,
+        ILogger<CommandHandler> logger,
+        IPlrClient plrClient,
+        PidpDbContext context) : ICommandHandler<Command, IDomainResult>
+    {
+        private readonly IClock clock = clock;
+        private readonly IKeycloakAdministrationClient keycloakClient = keycloakClient;
+        private readonly ILogger<CommandHandler> logger = logger;
+        private readonly IPlrClient plrClient = plrClient;
+        private readonly PidpDbContext context = context;
+
+        public async Task<IDomainResult> HandleAsync(Command command)
+        {
+            var dto = await this.context.Parties
+                .Where(party => party.Id == command.PartyId)
+                .Select(party => new
+                {
+                    AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.InfantRsvEforms),
+                    UserIds = party.Credentials
+                        .Where(credential => credential.IdentityProvider == IdentityProviders.BCServicesCard || credential.IdentityProvider == IdentityProviders.BCProvider)
+                        .Select(credential => credential.UserId),
+                    party.Email,
+                    party.Cpn,
+                })
+                .SingleAsync();
+
+            if (dto.AlreadyEnroled
+                || dto.Email == null)
+            {
+                this.logger.LogAccessRequestDenied(command.PartyId);
+                return DomainResult.Failed();
+            }
+
+            if (dto.Cpn == null)
+            {
+                // Check status of Endorsements
+                var endorsementCpns = await this.context.ActiveEndorsementRelationships(command.PartyId)
+                    .Select(relationship => relationship.Party!.Cpn)
+                    .ToListAsync();
+
+                var endorsementPlrStanding = await this.plrClient.GetAggregateStandingsDigestAsync(endorsementCpns);
+
+                if (!endorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding &&
+                    !endorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding)
+                {
+                    this.logger.LogAccessRequestDenied(command.PartyId);
+                    return DomainResult.Failed();
+                }
+            }
+            else
+            {
+                if (!IsEligible(await this.plrClient.GetStandingsDigestAsync(dto.Cpn)))
+                {
+                    this.logger.LogAccessRequestDenied(command.PartyId);
+                    return DomainResult.Failed();
+                }
+            }
+
+            foreach (var userId in dto.UserIds)
+            {
+                if (!await this.keycloakClient.AssignAccessRoles(userId, MohKeycloakEnrolment.InfantRsvEforms))
+                {
+                    return DomainResult.Failed();
+                }
+            }
+
+            this.context.AccessRequests.Add(new AccessRequest
+            {
+                PartyId = command.PartyId,
+                AccessTypeCode = AccessTypeCode.InfantRsvEforms,
+                RequestedOn = this.clock.GetCurrentInstant()
+            });
+
+            await this.context.SaveChangesAsync();
+
+            return DomainResult.Success();
+        }
+    }
+}
+
+public static partial class InfantRsvEformsLoggingExtensions
+{
+    [LoggerMessage(1, LogLevel.Warning, "Infant RSV eForms Access Request for Party {partyId} denied; did not meet all prerequisites.")]
+    public static partial void LogAccessRequestDenied(this ILogger<InfantRsvEforms.CommandHandler> logger, int partyId);
+}

--- a/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
+++ b/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
@@ -82,7 +82,8 @@ public class InfantRsvEforms
                 var endorsementPlrStanding = await this.plrClient.GetAggregateStandingsDigestAsync(endorsementCpns);
 
                 if (!endorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding &&
-                    !endorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding)
+                    !endorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding &&
+                    !endorsementPlrStanding.With(IdentifierType.Midwife).HasGoodStanding)
                 {
                     this.logger.LogAccessRequestDenied(command.PartyId);
                     return DomainResult.Failed();

--- a/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
+++ b/backend/webapi/Features/AccessRequests/InfantRsvEforms.cs
@@ -15,7 +15,7 @@ using Pidp.Models.Lookups;
 
 public class InfantRsvEforms
 {
-    public static IdentifierType[] AllowedIdentifierTypes => [IdentifierType.PhysiciansAndSurgeons, IdentifierType.Nurse];
+    public static IdentifierType[] AllowedIdentifierTypes => [IdentifierType.PhysiciansAndSurgeons, IdentifierType.Nurse, IdentifierType.Midwife];
 
     public static bool IsEligible(PlrStandingsDigest partyPlrStanding)
     {
@@ -55,15 +55,18 @@ public class InfantRsvEforms
                 {
                     AlreadyEnroled = party.AccessRequests.Any(request => request.AccessTypeCode == AccessTypeCode.InfantRsvEforms),
                     UserIds = party.Credentials
-                        .Where(credential => credential.IdentityProvider == IdentityProviders.BCServicesCard || credential.IdentityProvider == IdentityProviders.BCProvider)
+                        .Where(credential => credential.IdentityProvider == IdentityProviders.BCServicesCard)
                         .Select(credential => credential.UserId),
                     party.Email,
                     party.Cpn,
                 })
                 .SingleAsync();
 
+            // UserIds holds only BC Services Card credentials, so an empty set means the
+            // Party has none; the role has nowhere to land and the request must be denied.
             if (dto.AlreadyEnroled
-                || dto.Email == null)
+                || dto.Email == null
+                || !dto.UserIds.Any())
             {
                 this.logger.LogAccessRequestDenied(command.PartyId);
                 return DomainResult.Failed();

--- a/backend/webapi/Features/CommonHandlers/EndorsementStandingUpdatedHandler.cs
+++ b/backend/webapi/Features/CommonHandlers/EndorsementStandingUpdatedHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Pidp.Data;
 using Pidp.Extensions;
+using Pidp.Features.AccessRequests;
 using static Pidp.Features.CommonHandlers.UpdateBcProviderAttributesConsumer;
 using Pidp.Infrastructure.Auth;
 using Pidp.Infrastructure.HttpClients.BCProvider;
@@ -57,4 +58,17 @@ public class UpdateBCProviderAfterEndorsementStandingUpdated(
 
         await this.bus.Publish(new UpdateBcProviderAttributes(party.Upn, attributes.AsAdditionalData()), cancellationToken);
     }
+}
+
+/// <summary>
+/// An MOA holds the Infant RSV eForms card on the strength of their endorsements, so losing the
+/// last endorser in good standing must take the role away again.
+/// </summary>
+public class RevokeInfantRsvEformsAfterEndorsementStandingUpdated(
+    IInfantRsvEformsRevocationService revocationService) : INotificationHandler<EndorsementStandingUpdated>
+{
+    private readonly IInfantRsvEformsRevocationService revocationService = revocationService;
+
+    public async Task Handle(EndorsementStandingUpdated notification, CancellationToken cancellationToken)
+        => await this.revocationService.RevokeIfIneligibleAsync(notification.PartyId, cancellationToken: cancellationToken);
 }

--- a/backend/webapi/Features/Parties/ProfileStatus.Model.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.Model.cs
@@ -263,10 +263,8 @@ public partial class ProfileStatus
                     // The Keycloak role is only ever granted to a BC Services Card credential,
                     // so a Party without one can never complete this enrolment.
                     { HasBCServicesCardCredential: false } or { UserIsHighAssuranceIdentity: false } => StatusCode.Locked,
-                    _ when InfantRsvEforms.IsEligible(profile.PartyPlrStanding) ||
-                        profile.EndorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding ||
-                        profile.EndorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding ||
-                        profile.EndorsementPlrStanding.With(IdentifierType.Midwife).HasGoodStanding => StatusCode.Incomplete,
+                    _ when InfantRsvEforms.IsEligible(profile.PartyPlrStanding)
+                        || InfantRsvEforms.IsEligibleByEndorsement(profile.EndorsementPlrStanding) => StatusCode.Incomplete,
                     _ => StatusCode.Locked
                 };
             }

--- a/backend/webapi/Features/Parties/ProfileStatus.Model.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.Model.cs
@@ -250,6 +250,25 @@ public partial class ProfileStatus
             }
         }
 
+        public class InfantRsvEformsSection : ProfileSection
+        {
+            internal override string SectionName => "infantRsvEforms";
+            public override string[] KeyWords => ["doctors", "nursing", "moa"];
+
+            protected override StatusCode Compute(ProfileData profile)
+            {
+                return profile switch
+                {
+                    { UserIsHighAssuranceIdentity: false } => StatusCode.Locked,
+                    _ when profile.HasEnrolment(AccessTypeCode.InfantRsvEforms) => StatusCode.Complete,
+                    _ when InfantRsvEforms.IsEligible(profile.PartyPlrStanding) ||
+                        profile.EndorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding ||
+                        profile.EndorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding => StatusCode.Incomplete,
+                    _ => StatusCode.Locked
+                };
+            }
+        }
+
         public class ImmsBCSection : ProfileSection
         {
             internal override string SectionName => "immsBC";

--- a/backend/webapi/Features/Parties/ProfileStatus.Model.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.Model.cs
@@ -265,7 +265,8 @@ public partial class ProfileStatus
                     { HasBCServicesCardCredential: false } or { UserIsHighAssuranceIdentity: false } => StatusCode.Locked,
                     _ when InfantRsvEforms.IsEligible(profile.PartyPlrStanding) ||
                         profile.EndorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding ||
-                        profile.EndorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding => StatusCode.Incomplete,
+                        profile.EndorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding ||
+                        profile.EndorsementPlrStanding.With(IdentifierType.Midwife).HasGoodStanding => StatusCode.Incomplete,
                     _ => StatusCode.Locked
                 };
             }

--- a/backend/webapi/Features/Parties/ProfileStatus.Model.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.Model.cs
@@ -259,8 +259,10 @@ public partial class ProfileStatus
             {
                 return profile switch
                 {
-                    { UserIsHighAssuranceIdentity: false } => StatusCode.Locked,
                     _ when profile.HasEnrolment(AccessTypeCode.InfantRsvEforms) => StatusCode.Complete,
+                    // The Keycloak role is only ever granted to a BC Services Card credential,
+                    // so a Party without one can never complete this enrolment.
+                    { HasBCServicesCardCredential: false } or { UserIsHighAssuranceIdentity: false } => StatusCode.Locked,
                     _ when InfantRsvEforms.IsEligible(profile.PartyPlrStanding) ||
                         profile.EndorsementPlrStanding.With(ProviderRoleType.MedicalDoctor).HasGoodStanding ||
                         profile.EndorsementPlrStanding.With(IdentifierType.Nurse).HasGoodStanding => StatusCode.Incomplete,

--- a/backend/webapi/Features/Parties/ProfileStatus.cs
+++ b/backend/webapi/Features/Parties/ProfileStatus.cs
@@ -80,6 +80,7 @@ public partial class ProfileStatus
                     ProfileSection.Create<HcimWebPcrSection>(data),
                     ProfileSection.Create<ImmsBCEformsSection>(data),
                     ProfileSection.Create<ImmsBCSection>(data),
+                    ProfileSection.Create<InfantRsvEformsSection>(data),
                     ProfileSection.Create<IvfSection>(data),
                     ProfileSection.Create<MSTeamsClinicMemberSection>(data),
                     ProfileSection.Create<MSTeamsPrivacyOfficerSection>(data),

--- a/backend/webapi/Infrastructure/HttpClients/Keycloak/IKeycloakAdministrationClient.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Keycloak/IKeycloakAdministrationClient.cs
@@ -78,6 +78,14 @@ public interface IKeycloakAdministrationClient
     Task<UserRepresentation?> GetUser(Guid userId);
 
     /// <summary>
+    /// Removes all the Access Roles of the given Enrolment from the User.
+    /// Returns true if the operation was successful.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="enrolment"></param>
+    Task<bool> RemoveAccessRoles(Guid userId, MohKeycloakEnrolment enrolment);
+
+    /// <summary>
     /// Removes the given Client Role from the User.
     /// Returns true if the operation was successful.
     /// </summary>

--- a/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakAdministrationClient.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakAdministrationClient.cs
@@ -206,6 +206,36 @@ public class KeycloakAdministrationClient(HttpClient httpClient, ILogger<Keycloa
         return result.Value;
     }
 
+    public async Task<bool> RemoveAccessRoles(Guid userId, MohKeycloakEnrolment enrolment)
+    {
+        if (!enrolment.AccessRoles.Any())
+        {
+            return true;
+        }
+
+        // We need both the name and ID of the role to remove it.
+        var roles = await this.GetClientRoles(enrolment.ClientId);
+        if (roles == null)
+        {
+            return false;
+        }
+
+        var rolesToRemove = roles.IntersectBy(enrolment.AccessRoles, role => role.Name);
+        if (rolesToRemove.Count() < enrolment.AccessRoles.Count())
+        {
+            // Some Roles were not found
+            return false;
+        }
+
+        var result = await this.DeleteAsync($"users/{userId}/role-mappings/clients/{rolesToRemove.First().ContainerId}", rolesToRemove);
+        if (result.IsSuccess)
+        {
+            this.Logger.LogClientRolesUnassigned(userId, enrolment.AccessRoles, enrolment.ClientId);
+        }
+
+        return result.IsSuccess;
+    }
+
     public async Task<bool> RemoveClientRole(Guid userId, Role role)
     {
         if (role.ClientRole != true)
@@ -267,4 +297,8 @@ public static partial class KeycloakAdministrationClientLoggingExtensions
 
     [LoggerMessage(9, LogLevel.Error, "Error when finding user with username {username}: multiple matching usernames found.")]
     public static partial void LogFindMultipleUsersError(this ILogger<BaseClient> logger, string username);
+
+    [LoggerMessage(10, LogLevel.Information, "User {userId} was unassigned Role(s) {roleNames} in Client {clientId}.")]
+    public static partial void LogClientRolesUnassigned(this ILogger<BaseClient> logger, Guid userId, IEnumerable<string> roleNames, string clientId);
+
 }

--- a/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakApiDefinitions.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Keycloak/KeycloakApiDefinitions.cs
@@ -11,6 +11,7 @@ public class MohKeycloakEnrolment
     public static readonly MohKeycloakEnrolment DriverFitness = new("DMFT-WEBAPP", AccessTypeCode.DriverFitness, "DMFT_ENROLLED");
     public static readonly MohKeycloakEnrolment HcimWebPcr = new("HCIMWEB", AccessTypeCode.HcimWebPcr, "READ_ONLY_ALL_SRC");
     public static readonly MohKeycloakEnrolment ImmsBCEforms = new("SAT-EFORMS", AccessTypeCode.ImmsBCEforms, "phsa_eforms_imms");
+    public static readonly MohKeycloakEnrolment InfantRsvEforms = new("SAT-EFORMS", AccessTypeCode.InfantRsvEforms, "phsa_eforms_infant_rsv");
     public static readonly MohKeycloakEnrolment ProviderReportingPortal = new("PRP-SERVICE", AccessTypeCode.ProviderReportingPortal, "MSPQI", "PMP");
     public static readonly MohKeycloakEnrolment SAEforms = new("SAT-EFORMS", AccessTypeCode.SAEforms, "phsa_eforms_sat");
 

--- a/backend/webapi/Infrastructure/HttpClients/Plr/PlrClientDefinitions.cs
+++ b/backend/webapi/Infrastructure/HttpClients/Plr/PlrClientDefinitions.cs
@@ -248,4 +248,26 @@ public class PlrStatusChangeLog
     public string? ProviderRoleType { get; set; }
     public string MspId { get; set; } = string.Empty;
 
+    // The Old* pair is only populated once plr-intake projects it; until then these
+    // deserialize as null and IsGoodStandingUnchanged() reports false.
+    public string? OldStatusCode { get; set; }
+    public string? OldStatusReasonCode { get; set; }
+    public string? NewStatusCode { get; set; }
+    public string? NewStatusReasonCode { get; set; }
+
+    /// <summary>
+    /// True when this change did not alter the Party's good standing. Used to skip work that
+    /// only depends on good standing, now that every status change is queued for processing.
+    /// Returns false when the previous status is unknown, so callers err towards doing the work.
+    /// </summary>
+    public bool IsGoodStandingUnchanged()
+    {
+        if (this.OldStatusCode == null && this.OldStatusReasonCode == null)
+        {
+            return false;
+        }
+
+        var previous = new PlrRecord { StatusCode = this.OldStatusCode, StatusReasonCode = this.OldStatusReasonCode };
+        return previous.IsGoodStanding() == this.IsGoodStanding;
+    }
 }

--- a/backend/webapi/Infrastructure/Services/PlrStatusUpdateSchedulingService.cs
+++ b/backend/webapi/Infrastructure/Services/PlrStatusUpdateSchedulingService.cs
@@ -22,9 +22,17 @@ public class PlrStatusUpdateSchedulingService(
             while (await this.timer.WaitForNextTickAsync(stoppingToken)
                 && !stoppingToken.IsCancellationRequested)
             {
-                using var scope = this.scopeFactory.CreateScope();
-                await scope.ServiceProvider.GetRequiredService<IPlrStatusUpdateService>()
-                    .DoWorkAsync(stoppingToken);
+                try
+                {
+                    using var scope = this.scopeFactory.CreateScope();
+                    await scope.ServiceProvider.GetRequiredService<IPlrStatusUpdateService>()
+                        .DoWorkAsync(stoppingToken);
+                }
+                catch (Exception e) when (e is not OperationCanceledException)
+                {
+                    // A single failed iteration must not stop the service; the next tick retries.
+                    this.logger.LogWorkIterationFailed(e);
+                }
             }
         }
         catch (Exception e)
@@ -56,4 +64,7 @@ public static partial class PlrStatusUpdateSchedulingServiceLoggingExtensions
 
     [LoggerMessage(3, LogLevel.Critical, "Unhandled exception in PLR Status Update Scheduling Service. Service stopped.")]
     public static partial void LogServiceHasStoppedUnexpectedly(this ILogger<PlrStatusUpdateSchedulingService> logger, Exception e);
+
+    [LoggerMessage(4, LogLevel.Error, "Unhandled exception during a PLR Status Update work iteration. The Service will continue.")]
+    public static partial void LogWorkIterationFailed(this ILogger<PlrStatusUpdateSchedulingService> logger, Exception e);
 }

--- a/backend/webapi/Infrastructure/Services/PlrStatusUpdateService.cs
+++ b/backend/webapi/Infrastructure/Services/PlrStatusUpdateService.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Pidp.Data;
 using Pidp.Extensions;
+using Pidp.Features.AccessRequests;
 using Pidp.Infrastructure.Auth;
 using Pidp.Infrastructure.HttpClients.BCProvider;
 using Pidp.Infrastructure.HttpClients.Plr;
@@ -11,12 +12,14 @@ using Pidp.Models.DomainEvents;
 
 public sealed class PlrStatusUpdateService(
     IBCProviderClient bcProviderClient,
+    IInfantRsvEformsRevocationService rsvRevocationService,
     IPlrClient plrClient,
     ILogger<PlrStatusUpdateService> logger,
     PidpDbContext context,
     PidpConfiguration config) : IPlrStatusUpdateService
 {
     private readonly IBCProviderClient bcProviderClient = bcProviderClient;
+    private readonly IInfantRsvEformsRevocationService rsvRevocationService = rsvRevocationService;
     private readonly IPlrClient plrClient = plrClient;
     private readonly ILogger<PlrStatusUpdateService> logger = logger;
     private readonly PidpDbContext context = context;
@@ -63,7 +66,10 @@ public sealed class PlrStatusUpdateService(
             party.DomainEvents.Add(new EndorsementStandingUpdated(relation.PartyId));
         }
 
-        if (party.Upns.Any())
+        // Every status change is now queued, not just those that flip good standing, so this block
+        // gates itself on the flip it has always depended on.
+        if (party.Upns.Any()
+            && !status.IsGoodStandingUnchanged())
         {
             var bcProviderAttributes = new BCProviderAttributes(this.clientId);
 
@@ -103,6 +109,20 @@ public sealed class PlrStatusUpdateService(
             }
         }
 
+        // Runs on every status change: RSV eligibility includes CPS postgrads, whose transitions
+        // do not necessarily move the good-standing flag.
+        try
+        {
+            await this.rsvRevocationService.RevokeIfIneligibleAsync(party.Id, status, stoppingToken);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            // A revocation that always threw would never be acked, blocking the head of the queue
+            // and stalling every other consumer. Failing to revoke leaves today's behaviour intact;
+            // stalling the pipeline does not. The service stages nothing before it can throw.
+            this.logger.LogRevocationFailed(party.Id, e);
+        }
+
         await this.context.SaveChangesAsync(stoppingToken);
 
         this.logger.LogStatusUpdateProcessed(status.Id);
@@ -117,4 +137,7 @@ public static partial class PlrStatusUpdateServiceLoggingExtensions
 
     [LoggerMessage(2, LogLevel.Information, "Status update {statusId} has been proccessed.")]
     public static partial void LogStatusUpdateProcessed(this ILogger<PlrStatusUpdateService> logger, int statusId);
+
+    [LoggerMessage(3, LogLevel.Error, "Unhandled exception while re-evaluating Infant RSV eForms eligibility for Party {partyId}. The rest of the status update was processed.")]
+    public static partial void LogRevocationFailed(this ILogger<PlrStatusUpdateService> logger, int partyId, Exception e);
 }

--- a/backend/webapi/Models/BusinessEvent.cs
+++ b/backend/webapi/Models/BusinessEvent.cs
@@ -69,6 +69,47 @@ public class LicenceStatusRoleUnassigned : PartyBusinessEvent
     }
 }
 
+public class AccessRequestRevoked : PartyBusinessEvent
+{
+    public static AccessRequestRevoked Create(int partyId, AccessTypeCode accessTypeCode, MohKeycloakEnrolment? enrolment, string? cpn, IEnumerable<Guid> userIds, string reason, string? trigger, Instant recordedOn)
+    {
+        return new AccessRequestRevoked
+        {
+            PartyId = partyId,
+            Description = $"Party's {accessTypeCode} Access Request was deleted and {FormatRoles(enrolment)} unassigned."
+                + $" Reason: {reason}."
+                + $" Trigger: {trigger ?? "not recorded"}."
+                + $" CPN: {cpn ?? "none (endorsement-based access)"}."
+                + $" Keycloak User Ids: {FormatUserIds(userIds)}.",
+            Severity = LogLevel.Information,
+            RecordedOn = recordedOn
+        };
+    }
+
+    public static AccessRequestRevoked CreateFailure(int partyId, AccessTypeCode accessTypeCode, MohKeycloakEnrolment? enrolment, string? cpn, IEnumerable<Guid> userIds, string reason, string? trigger, Instant recordedOn)
+    {
+        return new AccessRequestRevoked
+        {
+            PartyId = partyId,
+            Description = $"Party was no longer entitled to their {accessTypeCode} Access Request but {FormatRoles(enrolment)} could not be unassigned; the Access Request was left in place to be retried."
+                + $" Reason: {reason}."
+                + $" Trigger: {trigger ?? "not recorded"}."
+                + $" CPN: {cpn ?? "none (endorsement-based access)"}."
+                + $" Keycloak User Ids: {FormatUserIds(userIds)}.",
+            Severity = LogLevel.Error,
+            RecordedOn = recordedOn
+        };
+    }
+
+    private static string FormatRoles(MohKeycloakEnrolment? enrolment) => enrolment == null
+        ? "no associated Keycloak role was"
+        : $"the {string.Join(", ", enrolment.AccessRoles)} role(s) in Client {enrolment.ClientId} were";
+
+    private static string FormatUserIds(IEnumerable<Guid> userIds) => userIds.Any()
+        ? string.Join(", ", userIds)
+        : "none";
+}
+
 public class BCProviderPasswordReset : PartyBusinessEvent
 {
     public static BCProviderPasswordReset Create(int partyId, string userPrincipalName, Instant recordedOn)

--- a/backend/webapi/Models/Lookups/AccessType.cs
+++ b/backend/webapi/Models/Lookups/AccessType.cs
@@ -15,7 +15,8 @@ public enum AccessTypeCode
     MSTeamsClinicMember,
     UserAccessAgreement,
     ImmsBCEforms,
-    HcimWebPcr
+    HcimWebPcr,
+    InfantRsvEforms
 }
 
 [Table("AccessTypeLookup")]
@@ -41,6 +42,7 @@ public class AccessTypeDataGenerator : ILookupDataGenerator<AccessType>
         new AccessType { Code = AccessTypeCode.MSTeamsClinicMember,      Name = "MS Teams for Clinical Use - Clinic Member"   },
         new AccessType { Code = AccessTypeCode.UserAccessAgreement,      Name = "OneHealthID Service Use Policy Agreement"    },
         new AccessType { Code = AccessTypeCode.ImmsBCEforms,             Name = "Immunization Entry eForm"                    },
-        new AccessType { Code = AccessTypeCode.HcimWebPcr,               Name = "Provincial Client Registry"                  }
+        new AccessType { Code = AccessTypeCode.HcimWebPcr,               Name = "Provincial Client Registry"                  },
+        new AccessType { Code = AccessTypeCode.InfantRsvEforms,          Name = "Infant RSV Immunization Request eForm"        }
     ];
 }

--- a/backend/webapi/Startup.cs
+++ b/backend/webapi/Startup.cs
@@ -18,6 +18,7 @@ using System.Text.Json;
 using Pidp.Data;
 using Pidp.Extensions;
 using Pidp.Features;
+using Pidp.Features.AccessRequests;
 using Pidp.Infrastructure;
 using Pidp.Infrastructure.Auth;
 using Pidp.Infrastructure.HealthChecks;
@@ -42,6 +43,7 @@ public class Startup(IConfiguration configuration)
             .AddRabbitMQ(config)
             .AddMediatR(opt => opt.RegisterServicesFromAssemblyContaining<Startup>())
             .AddScoped<IEmailService, EmailService>()
+            .AddScoped<IInfantRsvEformsRevocationService, InfantRsvEformsRevocationService>()
             .AddScoped<IPidpAuthorizationService, PidpAuthorizationService>()
             .AddScoped<IPlrStatusUpdateService, PlrStatusUpdateService>()
             .AddSingleton<IClock>(SystemClock.Instance)

--- a/workspace/apps/pidp/src/app/core/services/document.service.ts
+++ b/workspace/apps/pidp/src/app/core/services/document.service.ts
@@ -12,6 +12,7 @@ export enum DocumentType {
   MS_TEAMS_IT_SECURITY_AGREEMENT = 'ms-teams-it-security-agreement',
   PROVIDER_REPORTING_PORTAL_COLLECTION_NOTICE = 'provider-reporting-portal-collection-notice',
   IMMSBC_EFORMS_COLLECTION_NOTICE = 'immsbc-eforms-collection-notice',
+  INFANT_RSV_EFORMS_COLLECTION_NOTICE = 'infant-rsv-eforms-collection-notice',
   PHARMACY_ADMIN_COLLECTION_NOTICE = 'pharmacy-admin-collection-notice',
 }
 
@@ -72,6 +73,10 @@ export class DocumentService {
         title: 'Immunization Entry eForm Collection Notice',
       },
       {
+        type: DocumentType.INFANT_RSV_EFORMS_COLLECTION_NOTICE,
+        title: 'Infant RSV Immunization Request eForm Collection Notice',
+      },
+      {
         type: DocumentType.PHARMACY_ADMIN_COLLECTION_NOTICE,
         title: 'Pharmacy Administration Collection Notice',
       },
@@ -123,6 +128,11 @@ export class DocumentService {
         return {
           ...this.getDocumentMetaData(documentType),
           content: this.getImmsBCEformsCollectionNotice(),
+        };
+      case DocumentType.INFANT_RSV_EFORMS_COLLECTION_NOTICE:
+        return {
+          ...this.getDocumentMetaData(documentType),
+          content: this.getInfantRsvEformsCollectionNotice(),
         };
       case DocumentType.PHARMACY_ADMIN_COLLECTION_NOTICE:
         return {
@@ -346,6 +356,16 @@ export class DocumentService {
       and will not be used for any other purpose other than the one stated above. If you have any questions
       about the collection of this personal information please contact PHSA's Information Access & Privacy
       Office at 1-855-229-9800 or at <a href="mailto:${this.config.emails.immsBCEformsSupport}">${this.config.emails.immsBCEformsSupport}</a>.
+    `;
+  }
+
+  public getInfantRsvEformsCollectionNotice(): string {
+    return `
+      Personal information is protected under BC privacy laws and is collected under the authority of section
+      26(c) of the Freedom of Information Protection of Privacy Act. All data will be securely stored at PHSA
+      and will not be used for any other purpose other than the one stated above. If you have any questions
+      about the collection of this personal information please contact PHSA's Information Access & Privacy
+      Office at 1-855-229-9800 or at <a href="mailto:${this.config.emails.infantRsvEformsSupport}">${this.config.emails.infantRsvEformsSupport}</a>.
     `;
   }
 

--- a/workspace/apps/pidp/src/app/features/access/access-routing.routes.ts
+++ b/workspace/apps/pidp/src/app/features/access/access-routing.routes.ts
@@ -65,6 +65,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: AccessRoutes.INFANT_RSV_EFORMS,
+    loadChildren: (): Promise<Routes> =>
+      import('./pages/infant-rsv-eforms/infant-rsv-eforms-routing.routes').then(
+        (m) => m.routes,
+      ),
+  },
+  {
     path: AccessRoutes.PROVINCIAL_ATTACHMENT_SYSTEM,
     loadChildren: (): Promise<Routes> =>
       import(

--- a/workspace/apps/pidp/src/app/features/access/access.routes.ts
+++ b/workspace/apps/pidp/src/app/features/access/access.routes.ts
@@ -6,6 +6,7 @@ export class AccessRoutes {
   public static readonly HCIM_ACCOUNT_TRANSFER = 'hcim-account-transfer';
   public static readonly HCIM_WEB_PCR = 'hcim-web-pcr';
   public static readonly IMMSBC_EFORMS = 'immsbc-eforms';
+  public static readonly INFANT_RSV_EFORMS = 'infant-rsv-eforms';
   public static readonly MS_TEAMS_PRIVACY_OFFICER = 'ms-teams-privacy-officer';
   public static readonly MS_TEAMS_CLINIC_MEMBER = 'ms-teams-clinic-member';
   public static readonly PROVIDER_REPORTING_PORTAL = 'provider-reporting-portal';

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms-resource.service.ts
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms-resource.service.ts
@@ -1,0 +1,36 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+
+import { Observable, catchError, throwError } from 'rxjs';
+
+import { NoContent, NoContentResponse } from '@bcgov/shared/data-access';
+
+import { ApiHttpClient } from '@app/core/resources/api-http-client.service';
+import { ProfileStatus } from '@app/features/portal/models/profile-status.model';
+import { PortalResource } from '@app/features/portal/portal-resource.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InfantRsvEformsResource {
+  private readonly apiResource = inject(ApiHttpClient);
+  private readonly portalResource = inject(PortalResource);
+
+  public getProfileStatus(partyId: number): Observable<ProfileStatus | null> {
+    return this.portalResource.getProfileStatus(partyId);
+  }
+
+  public requestAccess(partyId: number): NoContent {
+    return this.apiResource
+      .post<NoContent>(
+        `parties/${partyId}/access-requests/infant-rsv-eforms`,
+        {},
+      )
+      .pipe(
+        NoContentResponse,
+        catchError((error: HttpErrorResponse) => {
+          return throwError(() => error);
+        }),
+      );
+  }
+}

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms-routing.routes.ts
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms-routing.routes.ts
@@ -1,0 +1,20 @@
+import { Routes } from '@angular/router';
+
+import { InfantRsvEformsPage } from './infant-rsv-eforms.page';
+import { infantRsvEformsResolver } from './infant-rsv-eforms.resolver';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: InfantRsvEformsPage,
+    resolve: {
+      infantRsvEformsStatusCode: infantRsvEformsResolver,
+    },
+    data: {
+      title: 'Infant RSV Immunization Request eForm and OneHealthID',
+      routes: {
+        root: '../../',
+      },
+    },
+  },
+];

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.constants.ts
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.constants.ts
@@ -1,0 +1,2 @@
+export const infantRsvEformsUrl = `https://www.eforms.healthbc.org/login`;
+export const infantRsvEformsSupportEmail = 'privacyandfoi@phsa.ca';

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.html
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.html
@@ -1,0 +1,90 @@
+<div class="container" uiPidpInjectViewportCss>
+  <app-breadcrumb [breadcrumbs]="breadcrumbsData"></app-breadcrumb>
+  <ui-page mode="full">
+    <h1>{{ title }}</h1>
+
+    @if (accessRequestFailed) {
+      <ui-alert
+        type="danger"
+        icon="error_outline"
+        iconType="outlined"
+        heading="Error Requesting Access">
+        <ng-container uiAlertContent>
+          <p>
+            Your request for access to Infant RSV Immunization Request eForm
+            could not be processed at this time. If this issue persists, contact
+            <a
+              uiAnchor
+              scheme="mailto"
+              [attr.href]="infantRsvEformsSupportEmail"></a>
+            for assistance.
+          </p>
+        </ng-container>
+      </ui-alert>
+    }
+
+    @if (enrolmentError) {
+      <app-enrolment-error></app-enrolment-error>
+    }
+
+    <ui-page-section>
+      <ui-page-section-subheader
+        icon="assignment"
+        heading="Infant RSV Immunization Request eForm">
+        <ng-container uiPageSectionSubheaderDesc>
+          {{ completed ? 'Enrolment Complete.' : 'Collection Notice.' }}
+        </ng-container>
+      </ui-page-section-subheader>
+    </ui-page-section>
+
+    @if (completed) {
+      <ui-alert
+        type="success"
+        icon="check_circle"
+        iconType="outlined"
+        heading="You have access">
+        <ng-container uiAlertContent>
+          <p>
+            You now have access to the Infant RSV Immunization Request eForm
+            application. You can log into the application using your BC Services
+            Card app.
+          </p>
+          <p>
+            Follow this link to Infant RSV Immunization Request eForm:<br />
+            <a uiAnchor [attr.href]="infantRsvEformsUrl"></a>
+          </p>
+          <p>
+            You will need to visit this link each time you want to submit an
+            Infant RSV Immunization Request eForm. It may be helpful to bookmark
+            this link for future use.
+          </p>
+        </ng-container>
+      </ui-alert>
+    } @else {
+      <ui-page-section>
+        <p>
+          Eligible infants can receive publicly funded RSV immunization
+          (nirsevimab) at birth in designated NICUs/perinatal units. Submit this
+          eForm for eligible children who have not been immunized and require
+          follow-up with public health or the provincial RSV program.
+        </p>
+        <p
+          class="collection-notice"
+          [innerHtml]="collectionNotice | safe: 'html'"></p>
+      </ui-page-section>
+    }
+
+    <ui-page-footer [mode]="'reverse'">
+      @if (!completed) {
+        <button
+          mat-flat-button
+          uiPageFooterAction
+          type="button"
+          color="primary"
+          (click)="onRequestAccess()">
+          Next
+        </button>
+      }
+    </ui-page-footer>
+  </ui-page>
+</div>

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.scss
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.scss
@@ -1,0 +1,30 @@
+.viewport-all {
+  padding: 1.25rem 0.75rem;
+
+  h1 {
+    color: #036;
+    font-size: 3.125rem;
+    font-weight: 700;
+    margin-bottom: 0;
+  }
+}
+
+.viewport-small {
+  fa-icon {
+    padding-left: 0.6rem;
+    padding-right: 0.6rem;
+    font-size: 1.5rem;
+  }
+
+  span {
+    font-size: 0.9rem;
+  }
+}
+
+.viewport-small,
+.viewport-xsmall {
+  h1 {
+    font-size: 40px;
+    line-height: 1.1;
+  }
+}

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.ts
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.page.ts
@@ -1,0 +1,140 @@
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
+import { AfterViewInit, Component, OnInit, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { catchError, noop, of, tap } from 'rxjs';
+
+import {
+  AlertComponent,
+  AlertContentDirective,
+  AnchorDirective,
+  InjectViewportCssClassDirective,
+  PageComponent,
+  PageFooterActionDirective,
+  PageFooterComponent,
+  PageSectionComponent,
+  PageSectionSubheaderComponent,
+  PageSectionSubheaderDescDirective,
+  SafePipe,
+} from '@bcgov/shared/ui';
+
+import { PartyService } from '@app/core/party/party.service';
+import { DocumentService } from '@app/core/services/document.service';
+import { LoggerService } from '@app/core/services/logger.service';
+import { SnowplowService } from '@app/core/services/snowplow.service';
+import { StatusCode } from '@app/features/portal/enums/status-code.enum';
+import { BreadcrumbComponent } from '@app/shared/components/breadcrumb/breadcrumb.component';
+
+import { AccessRoutes } from '../../access.routes';
+import { EnrolmentErrorComponent } from '../../components/enrolment-error/enrolment-error.component';
+import { InfantRsvEformsResource } from './infant-rsv-eforms-resource.service';
+import {
+  infantRsvEformsSupportEmail,
+  infantRsvEformsUrl,
+} from './infant-rsv-eforms.constants';
+
+@Component({
+  selector: 'app-infant-rsv-eforms',
+  templateUrl: './infant-rsv-eforms.page.html',
+  styleUrls: ['./infant-rsv-eforms.page.scss'],
+  imports: [
+    AlertComponent,
+    AlertContentDirective,
+    AnchorDirective,
+    BreadcrumbComponent,
+    EnrolmentErrorComponent,
+    InjectViewportCssClassDirective,
+    MatButtonModule,
+    PageComponent,
+    PageFooterActionDirective,
+    PageFooterComponent,
+    PageSectionComponent,
+    PageSectionSubheaderComponent,
+    PageSectionSubheaderDescDirective,
+    SafePipe,
+  ],
+})
+export class InfantRsvEformsPage implements OnInit, AfterViewInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly partyService = inject(PartyService);
+  private readonly resource = inject(InfantRsvEformsResource);
+  private readonly logger = inject(LoggerService);
+  private readonly snowplowService = inject(SnowplowService);
+
+  public title: string;
+  public collectionNotice: string;
+  public completed: boolean | null;
+  public accessRequestFailed: boolean;
+  public infantRsvEformsUrl: string;
+  public infantRsvEformsSupportEmail: string;
+  public enrolmentError: boolean;
+  public AccessRoutes = AccessRoutes;
+  public breadcrumbsData: Array<{ title: string; path: string }> = [
+    { title: 'Home', path: '' },
+    {
+      title: 'Access',
+      path: AccessRoutes.routePath(AccessRoutes.ACCESS_REQUESTS),
+    },
+    { title: 'Infant RSV Immunization Request eForm', path: '' },
+  ];
+
+  public constructor() {
+    const documentService = inject(DocumentService);
+
+    const routeData = this.route.snapshot.data;
+    this.title = routeData.title;
+    this.collectionNotice =
+      documentService.getInfantRsvEformsCollectionNotice();
+    this.completed =
+      routeData.infantRsvEformsStatusCode === StatusCode.COMPLETED;
+    this.accessRequestFailed = false;
+    this.infantRsvEformsUrl = infantRsvEformsUrl;
+    this.infantRsvEformsSupportEmail = infantRsvEformsSupportEmail;
+    this.enrolmentError = false;
+  }
+
+  public onRequestAccess(): void {
+    this.resource
+      .requestAccess(this.partyService.partyId)
+      .pipe(
+        tap(() => {
+          this.completed = true;
+          this.enrolmentError = false;
+        }),
+        catchError((error: HttpErrorResponse) => {
+          if (error.status === HttpStatusCode.BadRequest) {
+            this.completed = false;
+            this.enrolmentError = true;
+            return of(noop());
+          }
+          this.accessRequestFailed = true;
+          return of(noop());
+        }),
+      )
+      .subscribe();
+  }
+
+  public ngOnInit(): void {
+    const partyId = this.partyService.partyId;
+
+    if (!partyId) {
+      this.logger.error('No party ID was provided');
+      return this.navigateToRoot();
+    }
+
+    if (this.completed === null) {
+      this.logger.error('No status code was provided');
+      return this.navigateToRoot();
+    }
+  }
+
+  public ngAfterViewInit(): void {
+    this.snowplowService.refreshLinkClickTracking();
+  }
+
+  private navigateToRoot(): void {
+    this.router.navigate([this.route.snapshot.data.routes.root]);
+  }
+}

--- a/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.resolver.ts
+++ b/workspace/apps/pidp/src/app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.resolver.ts
@@ -1,0 +1,30 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+
+import { catchError, map, of } from 'rxjs';
+
+import { PartyService } from '@app/core/party/party.service';
+import { StatusCode } from '@app/features/portal/enums/status-code.enum';
+import { ProfileStatus } from '@app/features/portal/models/profile-status.model';
+
+import { InfantRsvEformsResource } from './infant-rsv-eforms-resource.service';
+
+export const infantRsvEformsResolver: ResolveFn<StatusCode | null> = () => {
+  const partyService = inject(PartyService);
+  const resource = inject(InfantRsvEformsResource);
+
+  if (!partyService.partyId) {
+    return of(null);
+  }
+
+  return resource.getProfileStatus(partyService.partyId).pipe(
+    map((profileStatus: ProfileStatus | null) => {
+      if (!profileStatus) {
+        return null;
+      }
+
+      return profileStatus.status.infantRsvEforms.statusCode;
+    }),
+    catchError(() => of(null)),
+  );
+};

--- a/workspace/apps/pidp/src/app/features/portal/state/access/access-group.model.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/access/access-group.model.ts
@@ -13,6 +13,7 @@ export const accessSectionKeys = [
   'hcimAccountTransfer',
   'hcimWebPcr',
   'immsBCEforms',
+  'infantRsvEforms',
   'driverFitness',
   'msTeamsPrivacyOfficer',
   'msTeamsClinicMember',
@@ -46,6 +47,7 @@ export interface AccessGroup extends IAccessGroup {
   hcimAccountTransfer: Section;
   hcimWebPcr: Section;
   immsBCEforms: Section;
+  infantRsvEforms: Section;
   driverFitness: Section;
   msTeamsPrivacyOfficer: Section;
   msTeamsClinicMember: Section;

--- a/workspace/apps/pidp/src/app/features/portal/state/access/infant-rsv-eforms-portal-section.class.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/access/infant-rsv-eforms-portal-section.class.ts
@@ -1,0 +1,86 @@
+import { Router } from '@angular/router';
+
+import { Observable } from 'rxjs';
+
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faSyringe, faUserCheck } from '@fortawesome/free-solid-svg-icons';
+
+import { AlertType } from '@bcgov/shared/ui';
+
+import { AccessRoutes } from '@app/features/access/access.routes';
+import { ShellRoutes } from '@app/features/shell/shell.routes';
+import { Constants } from '@app/shared/constants';
+
+import { StatusCode } from '../../enums/status-code.enum';
+import { ProfileStatus } from '../../models/profile-status.model';
+import { PortalSectionAction } from '../portal-section-action.model';
+import { PortalSectionKey } from '../portal-section-key.type';
+import { IPortalSection } from '../portal-section.model';
+
+export class InfantRsvEformsPortalSection implements IPortalSection {
+  public readonly key: PortalSectionKey;
+  public heading: string;
+  public description: string;
+  public faSyringe = faSyringe;
+  public faUserCheck = faUserCheck;
+  public keyWords: string[];
+  public completedMessage: string;
+
+  public constructor(
+    private readonly profileStatus: ProfileStatus,
+    private readonly router: Router,
+  ) {
+    this.key = 'infantRsvEforms';
+    this.heading = 'Infant RSV Immunization Request eForm';
+    this.description = `Submit this eForm for infants who are eligible for publicly funded RSV immunization and require follow-up with public health or the provincial RSV program.`;
+    this.keyWords = profileStatus.status.infantRsvEforms.keyWords || [];
+    this.completedMessage = Constants.accessGrantedText;
+  }
+
+  public get hint(): string {
+    return '1 minute to complete';
+  }
+
+  /**
+   * @description
+   * Get the properties that define the action on the section.
+   */
+  public get action(): PortalSectionAction {
+    const statusCode = this.getStatusCode();
+    return {
+      label: statusCode === StatusCode.COMPLETED ? 'View' : 'Request',
+      route: AccessRoutes.routePath(AccessRoutes.INFANT_RSV_EFORMS),
+      disabled: statusCode === StatusCode.NOT_AVAILABLE,
+    };
+  }
+
+  public get statusType(): AlertType {
+    return this.getStatusCode() === StatusCode.COMPLETED ? 'success' : 'warn';
+  }
+
+  public get status(): string {
+    const statusCode = this.getStatusCode();
+
+    switch (statusCode) {
+      case StatusCode.AVAILABLE:
+        return 'You are eligible to use Infant RSV Immunization Request eForm';
+      case StatusCode.COMPLETED:
+        return 'Completed';
+      default:
+        return 'Incomplete';
+    }
+  }
+
+  public get icon(): IconProp {
+    const statusCode = this.getStatusCode();
+    return statusCode === StatusCode.COMPLETED ? faUserCheck : faSyringe;
+  }
+
+  public performAction(): Observable<void> | void {
+    this.router.navigate([ShellRoutes.routePath(this.action.route)]);
+  }
+
+  private getStatusCode(): StatusCode {
+    return this.profileStatus.status.infantRsvEforms.statusCode;
+  }
+}

--- a/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
@@ -16,6 +16,7 @@ import { HcimAccountTransferPortalSection } from './access/hcim-account-transfer
 import { HcimWebPcrPortalSection } from './access/hcim-web-pcr-portal-section.class';
 import { ImmsBCEformsPortalSection } from './access/immsbc-eforms-portal-section.class';
 import { ImmsbcPortalSection } from './access/immscbc-portal-section.class';
+import { InfantRsvEformsPortalSection } from './access/infant-rsv-eforms-portal-section.class';
 import { IvfPortalSection } from './access/ivf-portal-section.class';
 import { MsTeamsClinicMemberPortalSection } from './access/ms-teams-clinic-member-portal-section.class';
 import { MsTeamsPrivacyOfficerPortalSection } from './access/ms-teams-privacy-officer-portal-section.class';
@@ -135,6 +136,11 @@ export class AccessStateBuilder {
       ...ArrayUtils.insertResultIf<IAccessSection>(
         this.insertSection('immsBCEforms', profileStatus),
         () => [new ImmsBCEformsPortalSection(profileStatus, this.router)],
+      ),
+      ...ArrayUtils.insertResultIf<IAccessSection>(
+        this.insertSection('infantRsvEforms', profileStatus) &&
+          this.permissionsService.hasRole([Role.FEATURE_PIDP_DEMO]),
+        () => [new InfantRsvEformsPortalSection(profileStatus, this.router)],
       ),
       ...ArrayUtils.insertResultIf<IAccessSection>(
         this.insertSection('halo', profileStatus) &&
@@ -283,6 +289,11 @@ export class PortalStateBuilder {
       ...ArrayUtils.insertResultIf<IPortalSection>(
         this.insertSection('immsBCEforms', profileStatus),
         () => [new ImmsBCEformsPortalSection(profileStatus, this.router)],
+      ),
+      ...ArrayUtils.insertResultIf<IPortalSection>(
+        this.insertSection('infantRsvEforms', profileStatus) &&
+          this.permissionsService.hasRole([Role.FEATURE_PIDP_DEMO]),
+        () => [new InfantRsvEformsPortalSection(profileStatus, this.router)],
       ),
     ];
   }

--- a/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
+++ b/workspace/apps/pidp/src/app/features/portal/state/portal-state.builder.ts
@@ -138,8 +138,7 @@ export class AccessStateBuilder {
         () => [new ImmsBCEformsPortalSection(profileStatus, this.router)],
       ),
       ...ArrayUtils.insertResultIf<IAccessSection>(
-        this.insertSection('infantRsvEforms', profileStatus) &&
-          this.permissionsService.hasRole([Role.FEATURE_PIDP_DEMO]),
+        this.insertSection('infantRsvEforms', profileStatus),
         () => [new InfantRsvEformsPortalSection(profileStatus, this.router)],
       ),
       ...ArrayUtils.insertResultIf<IAccessSection>(
@@ -291,8 +290,7 @@ export class PortalStateBuilder {
         () => [new ImmsBCEformsPortalSection(profileStatus, this.router)],
       ),
       ...ArrayUtils.insertResultIf<IPortalSection>(
-        this.insertSection('infantRsvEforms', profileStatus) &&
-          this.permissionsService.hasRole([Role.FEATURE_PIDP_DEMO]),
+        this.insertSection('infantRsvEforms', profileStatus),
         () => [new InfantRsvEformsPortalSection(profileStatus, this.router)],
       ),
     ];

--- a/workspace/apps/pidp/src/environments/environment.model.ts
+++ b/workspace/apps/pidp/src/environments/environment.model.ts
@@ -21,6 +21,7 @@ export interface AppEnvironment extends EnvironmentConfig {
     msTeamsSupport: string;
     doctorsTechnologyOfficeSupport: string;
     immsBCEformsSupport: string;
+    infantRsvEformsSupport: string;
   };
   urls: {
     bcscAppDownload: string;

--- a/workspace/apps/pidp/src/environments/environment.prod.ts
+++ b/workspace/apps/pidp/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 import { driverFitnessSupportEmail } from '@app/features/access/pages/driver-fitness/driver-fitness.constants';
 import { hcimWebAccountTransferSupport } from '@app/features/access/pages/hcim-account-transfer/hcim-account-transfer-constants';
 import { immsBCEformsSupportEmail } from '@app/features/access/pages/immsbc-eforms/immsbc-eforms.constants';
+import { infantRsvEformsSupportEmail } from '@app/features/access/pages/infant-rsv-eforms/infant-rsv-eforms.constants';
 import {
   doctorsTechnologyOfficeEmail,
   doctorsTechnologyOfficeUrl,
@@ -36,6 +37,7 @@ export const environment: AppEnvironment = {
     msTeamsSupport: msTeamsSupportEmail,
     doctorsTechnologyOfficeSupport: doctorsTechnologyOfficeEmail,
     immsBCEformsSupport: immsBCEformsSupportEmail,
+    infantRsvEformsSupport: infantRsvEformsSupportEmail,
   },
   urls: {
     bcscAppDownload: `https://www2.gov.bc.ca/gov/content/governments/government-id/bcservicescardapp/download-app`,

--- a/workspace/apps/pidp/src/test/mock-profile-status.ts
+++ b/workspace/apps/pidp/src/test/mock-profile-status.ts
@@ -40,6 +40,7 @@ export class MockProfileStatus {
         complianceTraining: { statusCode: StatusCode.AVAILABLE },
         provincialAttachmentSystem: { statusCode: StatusCode.AVAILABLE },
         immsBCEforms: { statusCode: StatusCode.AVAILABLE },
+        infantRsvEforms: { statusCode: StatusCode.AVAILABLE },
         externalAccounts: { statusCode: StatusCode.AVAILABLE },
         halo: { statusCode: StatusCode.AVAILABLE },
         ivf: { statusCode: StatusCode.AVAILABLE },


### PR DESCRIPTION
Add missing logic changes to RSV. Role now assigned only to BCSC and Midwives authorization.

Role Removal logic added:
Alter logic on PLR intake in order to process when a user standing changes if the user access to RSV should be revoked. Changes include - Role removal logic and improvements on processing + logging on BusinessEvents when access is removed.
Note that BCProvider functionality is untouched and the filter for when to process changes on BCProvider was moved to PlrStatusUpdateService.cs line 72.